### PR TITLE
Alternative CognitoClient

### DIFF
--- a/express/@types/StubCognitoClient/index.d.ts
+++ b/express/@types/StubCognitoClient/index.d.ts
@@ -1,0 +1,18 @@
+export interface Overrides {
+    createUser?: Override[]
+}
+
+export interface Override {
+    criteria: Critereon[],l
+    action: Action
+}
+
+export interface Critereon {
+    parameter: string,
+    value: string
+}
+
+export interface Action {
+    throw?: string,
+    return?: any
+}

--- a/express/config.json
+++ b/express/config.json
@@ -1,0 +1,16 @@
+{
+  "createUser": [
+    {
+      "parameter": "email",
+      "value": "inuse@foo.gov.uk",
+      "throw": "UsernameExistsException"
+    },
+    {
+      "parameter": "email",
+        "value": "returnsomething@foo.gov.uk",
+      "return": {
+        "$metadata": {"foo":  "bar"}
+      }
+    }
+  ]
+}

--- a/express/otherConfig.json
+++ b/express/otherConfig.json
@@ -1,0 +1,15 @@
+{
+  "createUser": [
+    {
+      "criteria": [
+        {
+          "parameter": "email",
+          "value": "inuse@foo.gov.uk"
+        }
+      ],
+      "action": {
+        "throw": "UsernameExistsException"
+      }
+    }
+  ]
+}

--- a/express/package.json
+++ b/express/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node -r 'dotenv/config' dist/app.js",
     "local": "npm run build && node -r 'dotenv/config' dist/app.js",
-    "dev": "nodemon --config nodemon.json -r 'dotenv/config' src/app.ts",
+    "dev": "COGNITO_CLIENT=StubCognitoClient nodemon --config nodemon.json -r 'dotenv/config' src/app.ts",
     "buildts": "tsc -p .",
     "buildsass": "node-sass --importer node_modules/node-sass-package-importer/dist/cli.js assets/css/app.scss dist/assets/app.css",
     "buildjs": "uglifyjs --verbose node_modules/govuk-frontend/govuk/all.js -o dist/assets/govuk-all.js && uglifyjs --verbose assets/javascripts/cookies.js -o dist/assets/cookies.js",

--- a/express/src/app.ts
+++ b/express/src/app.ts
@@ -5,12 +5,18 @@ import signIn from "./routes/sign-in";
 import bodyParser from 'body-parser';
 import cookieParser from 'cookie-parser';
 import sessions from 'express-session';
-import {CognitoClient} from "./lib/cognito";
 import {AuthenticationResultType} from "@aws-sdk/client-cognito-identity-provider";
 import manageAccount from "./routes/manage-account";
+import CognitoInterface from "./lib/cognito/CognitoInterface";
+import(`./lib/cognito/${process.env.COGNITO_CLIENT||"CognitoClient"}`).then(
+    client => {
+        app.set('cognitoClient', new client.default.CognitoClient);
+    }
+);
 
 const app = express();
-app.set('cognitoClient', new CognitoClient());
+
+
 app.use('/dist', express.static('./dist/assets'));
 app.use(express.static('./dist'));
 app.use(bodyParser.urlencoded({

--- a/express/src/lib/cognito/CognitoClient.ts
+++ b/express/src/lib/cognito/CognitoClient.ts
@@ -10,9 +10,20 @@ import {
     RespondToAuthChallengeCommand,
     UpdateUserAttributesCommand,
     AdminUpdateUserAttributesCommand,
-    AdminGetUserCommand
+    AdminGetUserCommand,
+    ConfirmSignUpCommandOutput,
+    AdminInitiateAuthCommandOutput,
+    RespondToAuthChallengeCommandOutput,
+    AdminGetUserCommandOutput,
+    AdminUpdateUserAttributesCommandOutput,
+    GetUserAttributeVerificationCodeCommandOutput,
+    VerifyUserAttributeCommandOutput
 } from "@aws-sdk/client-cognito-identity-provider";
-import CognitoInterface from "./cognito/CognitoInterface";
+import CognitoInterface from "./CognitoInterface";
+import {
+    AdminCreateUserCommandOutput
+} from "@aws-sdk/client-cognito-identity-provider/dist-types/commands/AdminCreateUserCommand";
+import {SignUpCommandOutput} from "@aws-sdk/client-cognito-identity-provider/dist-types/commands/SignUpCommand";
 
 
 export class CognitoClient implements CognitoInterface {
@@ -45,7 +56,7 @@ If the app is being deployed to PaaS then you may have to update manifest.yaml o
         }
     }
 
-    async createUser(email: string) {
+    async createUser(email: string): Promise<AdminCreateUserCommandOutput> {
         console.debug(`Adding a user with email ${{email}}`);
         let createUserParams = {
             DesiredDeliveryMediums: [ "EMAIL" ],
@@ -59,36 +70,7 @@ If the app is being deployed to PaaS then you may have to update manifest.yaml o
         return await this.cognitoClient.send(command);
     }
 
-    async register(email: string, password: string, phone_number: string) {
-        console.debug("Registering ...")
-        let signUpParams = {
-            ClientId: this.clientId,
-            Username: email,
-            Password: password,
-            UserAttributes: [
-                {Name: "email", Value: email},
-                {Name: "phone_number", Value: phone_number}]
-        }
-
-
-        let command = new SignUpCommand(signUpParams);
-        console.debug("Sending register command to Cognito")
-        return await this.cognitoClient.send(command);
-    }
-
-    async verify(confirmationCode: string, username: string) {
-        let params = {
-            UserPoolId: this.userPoolId,
-            ClientId: this.clientId,
-            ConfirmationCode: confirmationCode,
-            Username: username
-        }
-
-        let command = new ConfirmSignUpCommand(params);
-        return await this.cognitoClient.send(command);
-    }
-
-    async login(email: string, password: string) {
+    async login(email: string, password: string): Promise<AdminInitiateAuthCommandOutput> {
         let params = {
             UserPoolId: this.userPoolId,
             ClientId: this.clientId,
@@ -103,7 +85,7 @@ If the app is being deployed to PaaS then you may have to update manifest.yaml o
         return await this.cognitoClient.send(command);
     }
 
-    async setNewPassword(email: string, password: string, session: string) {
+    async setNewPassword(email: string, password: string, session: string): Promise<RespondToAuthChallengeCommandOutput> {
         let params = {
             ChallengeName: "NEW_PASSWORD_REQUIRED",
             ChallengeResponses: {
@@ -117,7 +99,7 @@ If the app is being deployed to PaaS then you may have to update manifest.yaml o
         return await this.cognitoClient.send(command);
     }
 
-    async getUser(username: string) {
+    async getUser(username: string): Promise<AdminGetUserCommandOutput> {
         let params = {
             Username: username,
             UserPoolId: this.userPoolId
@@ -127,7 +109,7 @@ If the app is being deployed to PaaS then you may have to update manifest.yaml o
         return await this.cognitoClient.send(command);
     }
 
-    async setEmailAsVerified(username: string) {
+    async setEmailAsVerified(username: string): Promise<AdminUpdateUserAttributesCommandOutput> {
         let params = {
             UserPoolId: this.userPoolId,
             Username: username,
@@ -142,7 +124,7 @@ If the app is being deployed to PaaS then you may have to update manifest.yaml o
         return await  this.cognitoClient.send(command);
     }
 
-    async setPhoneNumber(username: string, phoneNumber: string) {
+    async setPhoneNumber(username: string, phoneNumber: string): Promise<AdminUpdateUserAttributesCommandOutput> {
         let params = {
             UserPoolId: this.userPoolId,
             Username: username,
@@ -157,7 +139,7 @@ If the app is being deployed to PaaS then you may have to update manifest.yaml o
         return await  this.cognitoClient.send(command);
     }
 
-    async sendMobileNumberVerificationCode(accessToken: string) {
+    async sendMobileNumberVerificationCode(accessToken: string): Promise<GetUserAttributeVerificationCodeCommandOutput> {
         let params = {
             AccessToken: accessToken,
             AttributeName: "phone_number"
@@ -166,7 +148,7 @@ If the app is being deployed to PaaS then you may have to update manifest.yaml o
         return await this.cognitoClient.send(command);
     }
 
-    async verifySmsCode(accessToken: string, code: string) {
+    async verifySmsCode(accessToken: string, code: string): Promise<VerifyUserAttributeCommandOutput> {
         const params = {
             AccessToken: accessToken,
             AttributeName: 'phone_number',

--- a/express/src/lib/cognito/CognitoInterface.ts
+++ b/express/src/lib/cognito/CognitoInterface.ts
@@ -1,7 +1,23 @@
 import {
-    AdminCreateUserCommandOutput
-} from "@aws-sdk/client-cognito-identity-provider/dist-types/commands/AdminCreateUserCommand";
+    AdminCreateUserCommandOutput,
+    SignUpCommandOutput,
+    AdminInitiateAuthCommandOutput,
+    ConfirmSignUpCommandOutput,
+    RespondToAuthChallengeCommandOutput,
+    AdminGetUserCommandOutput,
+    AdminUpdateUserAttributesCommandOutput,
+    GetUserAttributeVerificationCodeCommandOutput,
+    VerifyUserAttributeCommandOutput
+
+} from "@aws-sdk/client-cognito-identity-provider";
 
 export default interface CognitoInterface {
     createUser(email: string): Promise<AdminCreateUserCommandOutput>;
+    login(email: string, password: string): Promise<AdminInitiateAuthCommandOutput>;
+    setNewPassword(email: string, password: string, session: string): Promise<RespondToAuthChallengeCommandOutput>;
+    getUser(username: string): Promise<AdminGetUserCommandOutput>;
+    setEmailAsVerified(username: string): Promise<AdminUpdateUserAttributesCommandOutput>;
+    setPhoneNumber(username: string, phoneNumber: string): Promise<AdminUpdateUserAttributesCommandOutput>;
+    sendMobileNumberVerificationCode(accessToken: string): Promise<GetUserAttributeVerificationCodeCommandOutput>;
+    verifySmsCode(accessToken: string, code: string): Promise<VerifyUserAttributeCommandOutput>;
 }

--- a/express/src/lib/cognito/StubCognitoClient.ts
+++ b/express/src/lib/cognito/StubCognitoClient.ts
@@ -1,0 +1,106 @@
+import CognitoInterface from "./CognitoInterface";
+
+import {
+    AdminGetUserCommandOutput,
+    AdminCreateUserCommandOutput,
+    AdminInitiateAuthCommandOutput,
+    AdminUpdateUserAttributesCommandOutput,
+    GetUserAttributeVerificationCodeCommandOutput,
+    RespondToAuthChallengeCommandOutput,
+    VerifyUserAttributeCommandOutput, UsernameExistsException
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { ServiceException } from '@aws-sdk/smithy-client/dist-types/exceptions'
+import {promises as fs} from "fs";
+import {Override, Overrides} from "../../../@types/StubCognitoClient";
+
+export class CognitoClient implements CognitoInterface {
+    overrides: Promise<any>;
+    otherOverrides: Promise<any>;
+
+    constructor() {
+        this.overrides = fs.readFile("./config.json");
+        this.otherOverrides = fs.readFile("./otherConfig.json");
+    }
+
+    private async getOtherOverrides(): Promise<Overrides> {
+        let thing: any = await this.otherOverrides;
+        let parsed: Overrides = JSON.parse(thing);
+        console.log(parsed);
+        console.log(parsed.createUser?.[0]);
+        return parsed;
+    }
+
+    async createUser(email: string): Promise<AdminCreateUserCommandOutput> {
+        let overrides: any = await this.getOverridesFor('createUser');
+        let otherOverrides = await this.getOtherOverrides();
+
+        //let conditions: (function boolean)[] = []
+        //otherOverrides.createUser?.filter()
+
+
+        if (overrides === undefined) {
+            return Promise.resolve({$metadata: {}});
+        }
+
+        let override: any = overrides.filter(
+            (override: { value: string }) => (override.value === email))[0];
+
+        if (override === undefined) {
+            return Promise.resolve({$metadata: {}});
+        }
+
+        if (override?.throw) {
+            throw this.getException(override.throw);
+        } else {
+            return Promise.resolve(override.return); // something from the config file
+        }
+    }
+
+    getUser(username: string): Promise<AdminGetUserCommandOutput> {
+        return Promise.resolve({$metadata: {}, Username: username});
+    }
+
+    login(email: string, password: string): Promise<AdminInitiateAuthCommandOutput> {
+        return Promise.resolve({Session: "What does a session value even look like?", $metadata: {}});
+    }
+
+    sendMobileNumberVerificationCode(accessToken: string): Promise<GetUserAttributeVerificationCodeCommandOutput> {
+        return Promise.resolve({$metadata: {}});
+    }
+
+    setEmailAsVerified(username: string): Promise<AdminUpdateUserAttributesCommandOutput> {
+        return Promise.resolve({UserAttributes: [{Name: 'email', Value: username}], $metadata: {}});
+    }
+
+    setNewPassword(email: string, password: string, session: string): Promise<RespondToAuthChallengeCommandOutput> {
+        return Promise.resolve({AuthenticationResult: {AccessToken: "let me in!"}, $metadata: {}});
+    }
+
+    setPhoneNumber(username: string, phoneNumber: string): Promise<AdminUpdateUserAttributesCommandOutput> {
+        return Promise.resolve({$metadata: {}});
+    }
+
+    verifySmsCode(accessToken: string, code: string): Promise<VerifyUserAttributeCommandOutput> {
+        return Promise.resolve({$metadata: {}});
+    }
+
+    private async getOverridesFor(method: string): Promise<any | undefined> {
+        let overrides: any = (await this.overrides);
+        if (overrides === undefined) {
+            return undefined;
+        }
+        return JSON.parse(overrides)[method];
+    }
+
+    private getException(exception: string): ServiceException  {
+        switch (exception) {
+            case 'UsernameExistsException' :
+                return new UsernameExistsException({$metadata: {}});
+        }
+        throw new Error('Unknown exception');
+    }
+
+}
+
+module.exports = {CognitoClient}

--- a/express/src/middleware/emailValidator.ts
+++ b/express/src/middleware/emailValidator.ts
@@ -1,0 +1,26 @@
+import {NextFunction, Request, Response} from "express";
+
+export function emailValidator(req: Request, res: Response, next: NextFunction) {
+    let emailAddress: string = req.body.emailAddress;
+    // trim
+    // ensure well-formed
+    // correct suffix
+
+    // modify req.body.email
+
+    if(true) {
+
+        req.body.emailAddress = emailAddress;
+        next();
+    } else {
+        const errorMessages = new Map<string, string>();
+        const values = new Map<string, string>();
+        errorMessages.set("emailAddress", "You must provide a government email address");
+        values.set('emailAddress', req.body.emailAddress);
+        res.render('create-account/get-email.njk', {
+            errorMessages: errorMessages,
+            values: values,
+            fieldOrder: ['emailAddress']
+        });
+    }
+}

--- a/express/src/middleware/mobileValidator.ts
+++ b/express/src/middleware/mobileValidator.ts
@@ -1,0 +1,16 @@
+import {NextFunction, Request, Response} from "express";
+
+export function mobileValidator(req: Request, res: Response, next: NextFunction) {
+    // remove whitespace
+    // ensure UK mobile
+    // convert to internation format
+
+    // modify req.body.telephone
+    let errorMessages = new Map<string, string>();
+    let values = new Map<string, string>();
+    if(true) {
+        next();
+    } else {
+        res.render('/create-account/get-email.njk', {fieldOrder: ['telephone'], values: values, errorMessages: errorMessages})
+    }
+}

--- a/express/src/routes/create-account-or-sign-in.ts
+++ b/express/src/routes/create-account-or-sign-in.ts
@@ -8,6 +8,8 @@ import {
     showEnterMobileForm,
     processEnterMobileForm, submitMobileVerificationCode, checkEmailOtp
 } from "../controllers/create-account";
+import {emailValidator} from "../middleware/emailValidator";
+import {mobileValidator} from "../middleware/mobileValidator";
 
 const router = express.Router();
 
@@ -15,7 +17,7 @@ router.get('/create-account-or-sign-in', (req: Request, res: Response) => {
     res.render('create-account-or-sign-in.njk');
 });
 router.get('/create/get-email', showGetEmailForm);
-router.post('/create/get-email', processGetEmailForm);
+router.post('/create/get-email', emailValidator, processGetEmailForm);
 
 router.get('/create/check-email', showCheckEmailForm);
 router.post('/create/check-email', checkEmailOtp);
@@ -24,9 +26,8 @@ router.get('/create/update-password', showNewPasswordForm);
 router.post('/create/update-password', updatePassword);
 
 router.get('/create/enter-mobile', showEnterMobileForm);
-router.post('/create/enter-mobile', processEnterMobileForm);
+router.post('/create/enter-mobile', mobileValidator, processEnterMobileForm);
 
 router.post('/create/verify-phone-code', submitMobileVerificationCode);
-
 
 export default router;


### PR DESCRIPTION
Provide an alternative implementation of the CognitoClient to enable development and testing without needing an AWS account / tokens
Alter `app.ts` to import the correct CognitoClient based on an environment variable - default to the actual implementation.
Update `package.json` so that the dev script uses StubCognitoClient
Provide a config for the StubCognitoClient so that calls to `createUser` can throw a `UsernameExistsException` if the email address inuse@foo.gov.uk is entered.
Provide an alternative format for the stub config to improve the implementation.  This is noise in this commit but it's a WIP.