### PR TITLE
DFA-732 Use lambda to store details of user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,5 +104,5 @@ dist
 .tern-port
 
 .idea/
-
+**/*.iml
 */.aws-sam

--- a/express/@types/OnboardingTableItem/index.d.ts
+++ b/express/@types/OnboardingTableItem/index.d.ts
@@ -1,0 +1,5 @@
+export interface OnboardingTableItem {
+    pk: string,
+    sk: string,
+    [propName: string]: any;
+}

--- a/express/@types/User/index.d.ts
+++ b/express/@types/User/index.d.ts
@@ -1,0 +1,9 @@
+export interface User {
+    [id | pk]: string;
+    [cognitoId | sk]: string;
+    data: string;
+    [firstName | first_name]: string | undefined;
+    [lastName | last_name]: string | undefined;
+    email: string | undefined;
+    phone: string | undefined;
+}

--- a/express/src/app.ts
+++ b/express/src/app.ts
@@ -8,6 +8,7 @@ import {AdminGetUserCommandOutput, AuthenticationResultType} from "@aws-sdk/clie
 import manageAccount from "./routes/manage-account";
 
 import testingRoutes from "./routes/testing-routes";
+import {User} from "../@types/User";
 
 const app = express();
 import(`./lib/cognito/${process.env.COGNITO_CLIENT||"CognitoClient"}`).then(
@@ -34,8 +35,9 @@ declare module 'express-session' {
         emailAddress: string;
         mobileNumber: string;
         session: string;
-        authenticationResult: AuthenticationResultType
-        user: AdminGetUserCommandOutput
+        authenticationResult: AuthenticationResultType;
+        cognitoUser: AdminGetUserCommandOutput;
+        selfServiceUser: User;
     }
 }
 

--- a/express/src/controllers/manage-account.ts
+++ b/express/src/controllers/manage-account.ts
@@ -1,13 +1,5 @@
-import express, {Request, Response} from "express";
+import {Request, Response} from "express";
 
 export const listServices = async function(req: Request, res: Response) {
-
-    // do database query, check whether user has any services.
-    // Zero services - show the add your service page
-    // One service - show page for that service
-    // More than one - list services
-
-
-
     res.render('manage-account/list-services.njk');
 }

--- a/express/src/lib/lambda-facade/LambdaFacade.ts
+++ b/express/src/lib/lambda-facade/LambdaFacade.ts
@@ -1,5 +1,26 @@
+import axios, {Axios, AxiosResponse} from "axios";
+import {OnboardingTableItem} from "../../../@types/OnboardingTableItem";
+import {User} from "../../../@types/User";
 
 class LambdaFacade {
+    private instance: Axios;
 
+    constructor(baseURL: string) {
+        this.instance = axios.create({
+            baseURL: baseURL,
+            headers: {
+                "Content-Type": "application/json"
+            }
+        });
+    }
+
+    async putUser(user: OnboardingTableItem, accessToken: string): Promise<AxiosResponse> {
+        return await (await this.instance).post('/Prod/put-user', user, {
+            headers: {
+                "authorised-by": accessToken
+            }
+        });
+    }
 }
-export default new LambdaFacade();
+
+export const lambdaFacadeInstance = new LambdaFacade(process.env.API_BASE_URL as string);

--- a/express/src/lib/lambda-facade/index.ts
+++ b/express/src/lib/lambda-facade/index.ts
@@ -1,1 +1,3 @@
-import LambdaFacade from './LambdaFacade';
+import {lambdaFacadeInstance} from './LambdaFacade';
+
+export default lambdaFacadeInstance;

--- a/express/src/routes/testing-routes.ts
+++ b/express/src/routes/testing-routes.ts
@@ -3,9 +3,6 @@ import express, {Request, Response} from 'express';
 const router = express.Router();
 
 //Testing route for service name get request
-router.get('/add-service-name', (req, res) => {
-  res.render("add-service-name.njk");
-});
 
 // Testing route for service name  get request with error
 router.get('/add-service-name-error', (req, res) => {

--- a/express/src/views/add-service-name.njk
+++ b/express/src/views/add-service-name.njk
@@ -32,7 +32,7 @@
               hint: {
                 text: "You can change this later"
               },
-              name: "serviceNamee",
+              name: "serviceName",
               id: "create-service-name",
               classes: "govuk-input--width-20",
               errorMessage: {

--- a/lambda/dynamo-api/src/handlers/put-service.ts
+++ b/lambda/dynamo-api/src/handlers/put-service.ts
@@ -1,4 +1,4 @@
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
 // Create clients and set shared const values outside of the handler.
 
 import DynamoClient from "../client/DynamoClient";
@@ -9,15 +9,11 @@ import {PutItemCommandOutput} from "@aws-sdk/client-dynamodb";
 const tableName = process.env.SAMPLE_TABLE;
 const client = new DynamoClient(tableName as string);
 
-export const putServiceHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-    if (event.httpMethod !== 'POST') {
-        throw new Error(`postMethod only accepts POST method, you tried: ${event.httpMethod} method.`);
-    }
-
-    const service = JSON.parse(event.body as string);
-    console.debug(service);
-
-    // Do whatever validation we want to do on the service
+export const putServiceHandler = async (event: APIGatewayProxyEvent, context: Context): Promise<APIGatewayProxyResult> => {
+    console.log("Received event:")
+    console.log(event);
+    console.log(context);
+    const service = event?.body ? JSON.parse(event.body as string) : event;
 
     let response = {statusCode: 200, body: JSON.stringify("OK")};
     await client

--- a/lambda/dynamo-api/src/handlers/put-user.ts
+++ b/lambda/dynamo-api/src/handlers/put-user.ts
@@ -5,12 +5,7 @@ const tableName = process.env.SAMPLE_TABLE;
 const client = new DynamoClient(tableName as string);
 
 export const putUserHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-    if (event.httpMethod !== 'POST') {
-        throw new Error(`postMethod only accepts POST method, you tried: ${event.httpMethod} method.`);
-    }
-
     const user = JSON.parse(event.body as string);
-    console.log(user);
 
     // Do whatever validation we want to do on the user
 

--- a/lambda/dynamo-api/template.yaml
+++ b/lambda/dynamo-api/template.yaml
@@ -71,7 +71,6 @@ Resources:
         Sourcemap: true
         EntryPoints:
           - src/handlers/put-service.ts
-
 Outputs:
   WebEndpoint:
     Description: "API Gateway endpoint URL for Prod stage"


### PR DESCRIPTION
Use LambdaFacade to do call to lambda from frontend.

Facade simplifies the creation of the payload and abstracts away the use of an Axios client to make the calls.  Much of the code that lived in the controller previously moves to the facade.

Add types to make working with TableItems and users easier.

Add cognitoUser to session and selfServiceUser to session - the cognitoUser contains stuff needed for sign-up / sign-in, the selfServiceUser is what gets stored.  Better names and arrangement will hopefully become clear in the future.