### PR TITLE
DFA-730 save service with lambda

### DIFF
--- a/express/@types/Service/index.d.ts
+++ b/express/@types/Service/index.d.ts
@@ -1,0 +1,6 @@
+export interface Service {
+    "pk": string,
+    "sk": string,
+    "data": string,
+    "service_name": string
+}

--- a/express/package-lock.json
+++ b/express/package-lock.json
@@ -10,8 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.80.0",
+        "@aws-sdk/util-dynamodb": "^3.100.0",
         "@types/cookie-parser": "^1.4.3",
         "@types/express-session": "^1.17.4",
+        "aws-jwt-verify": "^3.1.0",
         "axios": "^0.24.0",
         "cookie-parser": "^1.4.6",
         "dotenv": "^10.0.0",
@@ -796,6 +798,17 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.100.0.tgz",
+      "integrity": "sha512-/i8HqHjjSpd1TA6RCJ1c0CtBXXgAi9gEDOUx1raILeZgRO0X/uK72u/N9+MOIeoSF5ZUWa4alJt2P282S2T3Jw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-hex-encoding": {
@@ -3057,6 +3070,14 @@
       },
       "engines": {
         "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/aws-jwt-verify": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aws-jwt-verify/-/aws-jwt-verify-3.1.0.tgz",
+      "integrity": "sha512-8BTDS3xEP5xhK6/mLEQXc7MfRRer5diV4Q2AD6ofoHQnaDbuDXG056egq4UCgo06+rmWQAC7/A6vVRZ/2FCs9g==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/aws-sign2": {
@@ -13084,6 +13105,14 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/util-dynamodb": {
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.100.0.tgz",
+      "integrity": "sha512-/i8HqHjjSpd1TA6RCJ1c0CtBXXgAi9gEDOUx1raILeZgRO0X/uK72u/N9+MOIeoSF5ZUWa4alJt2P282S2T3Jw==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
     "@aws-sdk/util-hex-encoding": {
       "version": "3.58.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.58.0.tgz",
@@ -14921,6 +14950,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+    },
+    "aws-jwt-verify": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aws-jwt-verify/-/aws-jwt-verify-3.1.0.tgz",
+      "integrity": "sha512-8BTDS3xEP5xhK6/mLEQXc7MfRRer5diV4Q2AD6ofoHQnaDbuDXG056egq4UCgo06+rmWQAC7/A6vVRZ/2FCs9g=="
     },
     "aws-sign2": {
       "version": "0.7.0",

--- a/express/package.json
+++ b/express/package.json
@@ -17,8 +17,10 @@
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.80.0",
+    "@aws-sdk/util-dynamodb": "^3.100.0",
     "@types/cookie-parser": "^1.4.3",
     "@types/express-session": "^1.17.4",
+    "aws-jwt-verify": "^3.1.0",
     "axios": "^0.24.0",
     "cookie-parser": "^1.4.6",
     "dotenv": "^10.0.0",

--- a/express/src/controllers/manage-account.ts
+++ b/express/src/controllers/manage-account.ts
@@ -1,5 +1,28 @@
-import {Request, Response} from "express";
+import express, {Request, Response} from "express";
+import router from "../routes/testing-routes";
+import lambdaFacadeInstance from "../lib/lambda-facade";
+import {randomUUID} from "crypto";
+import {User} from "../../@types/User";
 
 export const listServices = async function(req: Request, res: Response) {
     res.render('manage-account/list-services.njk');
 }
+
+export const showAddServiceForm = async function (req: Request, res: Response) {
+    res.render("add-service-name.njk");
+}
+export const processAddServiceForm = async function (req: Request, res: Response) {
+    console.log(req.body)
+    const uuid = randomUUID();
+    const service = {
+        "pk": `service#${uuid}`,
+        "sk": `service#${uuid}`,
+        "data": req.body.serviceName,
+        "service_name": req.body.serviceName
+    }
+    let user = req.session.selfServiceUser as User;
+    console.log(service);
+    await lambdaFacadeInstance.newService(service, req.session.authenticationResult?.AccessToken as string, user);
+    res.redirect("/create-service");
+}
+

--- a/express/src/controllers/manage-account.ts
+++ b/express/src/controllers/manage-account.ts
@@ -21,8 +21,15 @@ export const processAddServiceForm = async function (req: Request, res: Response
         "service_name": req.body.serviceName
     }
     let user = req.session.selfServiceUser as User;
-    console.log(service);
-    await lambdaFacadeInstance.newService(service, req.session.authenticationResult?.AccessToken as string, user);
+    try {
+        let newUser: any = {};
+        // @ts-ignore
+        Object.keys(user).forEach(key => newUser[key] = user[key]["S"])
+        console.log(newUser)
+        await lambdaFacadeInstance.newService(service, newUser, req.session.authenticationResult?.AccessToken as string);
+    } catch (error) {
+        console.error(error);
+    }
     res.redirect("/create-service");
 }
 

--- a/express/src/controllers/sign-in.ts
+++ b/express/src/controllers/sign-in.ts
@@ -3,7 +3,8 @@ import express, {Request, Response} from "express";
 import {
     AuthenticationResultType,
     NotAuthorizedException,
-    UsernameExistsException
+    UsernameExistsException,
+    AttributeType
 } from "@aws-sdk/client-cognito-identity-provider";
 
 export const showSignInForm = async function(req: Request, res: Response) {
@@ -35,7 +36,8 @@ export const processSignInForm = async function(req: Request, res: Response) {
         const response = await cognitoClient.login(email, password);
         req.session.authenticationResult = response.AuthenticationResult;
         req.session.emailAddress = email;
-        res.redirect('/account/list-services');
+        req.session.selfServiceUser = {data: "", email: "", phone: ""}
+        res.redirect('/add-service-name');
         return;
     } catch (error) {
         if(error instanceof NotAuthorizedException) {

--- a/express/src/controllers/sign-in.ts
+++ b/express/src/controllers/sign-in.ts
@@ -1,11 +1,17 @@
 import express, {Request, Response} from "express";
-
+import LambdaFacade from "../lib/lambda-facade";
 import {
     AuthenticationResultType,
     NotAuthorizedException,
     UsernameExistsException,
-    AttributeType
+    AttributeType,
+    AdminInitiateAuthCommandOutput
 } from "@aws-sdk/client-cognito-identity-provider";
+
+import {marshall, unmarshall} from "@aws-sdk/util-dynamodb";
+
+import CognitoInterface from "../lib/cognito/CognitoInterface";
+import {User} from "../../@types/User";
 
 export const showSignInForm = async function(req: Request, res: Response) {
     res.render('sign-in.njk', {values: new Map<String, String>(), errorMessages: new Map<String, String>()});
@@ -31,14 +37,10 @@ export const processSignInForm = async function(req: Request, res: Response) {
         return;
     }
 
-    const cognitoClient = req.app.get('cognitoClient');
+    const cognitoClient: CognitoInterface = req.app.get('cognitoClient');
+    let response: AdminInitiateAuthCommandOutput;
     try {
-        const response = await cognitoClient.login(email, password);
-        req.session.authenticationResult = response.AuthenticationResult;
-        req.session.emailAddress = email;
-        req.session.selfServiceUser = {data: "", email: "", phone: ""}
-        res.redirect('/add-service-name');
-        return;
+         response = await cognitoClient.login(email, password);
     } catch (error) {
         if(error instanceof NotAuthorizedException) {
             errorMessages.set('email', 'Either your email address or password was wrong');
@@ -47,4 +49,19 @@ export const processSignInForm = async function(req: Request, res: Response) {
         }
         throw error;
     }
+
+    req.session.authenticationResult = response.AuthenticationResult;
+    req.session.emailAddress = email;
+
+    const payload = (req.session.authenticationResult?.IdToken as string).split('.');
+    const claims = Buffer.from(payload[1], 'base64').toString('utf-8');
+    const cognitoId = JSON.parse(claims)["cognito:username"];
+
+    console.log(cognitoId)
+    req.session.selfServiceUser = (await LambdaFacade.getUserByCognitoId(`cognito_username#${cognitoId}`, response?.AuthenticationResult?.AccessToken as string)).data.Items[0]
+    console.log(req.session.selfServiceUser as User);
+    res.redirect('/add-service-name');
+    return;
+
+
 }

--- a/express/src/lib/lambda-facade/LambdaFacade.ts
+++ b/express/src/lib/lambda-facade/LambdaFacade.ts
@@ -1,6 +1,7 @@
 import axios, {Axios, AxiosResponse} from "axios";
 import {OnboardingTableItem} from "../../../@types/OnboardingTableItem";
 import {User} from "../../../@types/User";
+import {Service} from "../../../@types/Service";
 
 class LambdaFacade {
     private instance: Axios;
@@ -16,6 +17,28 @@ class LambdaFacade {
 
     async putUser(user: OnboardingTableItem, accessToken: string): Promise<AxiosResponse> {
         return await (await this.instance).post('/Prod/put-user', user, {
+            headers: {
+                "authorised-by": accessToken
+            }
+        });
+    }
+
+    async getUserByCognitoId(cognitoId: string, accessToken: string): Promise<AxiosResponse> {
+        return await (await this.instance).post('/Prod/get-user', cognitoId, {
+            headers: {
+                "authorised-by": accessToken
+            }
+        });
+    }
+
+    async newService(service: Service, user: User, accessToken: string): Promise<AxiosResponse> {
+        let body = {
+            service: service,
+            user: user
+        }
+        console.log("SENDING TO STEP FUNCTION ".repeat(10))
+        console.log(JSON.stringify(body))
+        return await (await this.instance).post('/Prod/new-service', JSON.stringify(body), {
             headers: {
                 "authorised-by": accessToken
             }

--- a/express/src/routes/manage-account.ts
+++ b/express/src/routes/manage-account.ts
@@ -1,8 +1,12 @@
 import express, {Request, Response} from "express";
 import {listServices} from "../controllers/manage-account";
 import {checkAuthorisation} from "../middleware/authoriser";
+import {showAddServiceForm, processAddServiceForm} from "../controllers/manage-account";
 
 const router = express.Router();
 router.get('/account/list-services', checkAuthorisation, listServices);
+
+router.get('/add-service-name', checkAuthorisation, showAddServiceForm);
+router.post('/create-service-name-validation', checkAuthorisation, processAddServiceForm);
 
 export default router;

--- a/lambda/dynamo-api/src/client/DynamoClient.ts
+++ b/lambda/dynamo-api/src/client/DynamoClient.ts
@@ -1,4 +1,4 @@
-import {DynamoDBClient, PutItemCommand, PutItemCommandOutput} from "@aws-sdk/client-dynamodb";
+import {DynamoDBClient, PutItemCommand, PutItemCommandOutput, GetItemCommand, GetItemCommandOutput, QueryCommand, QueryCommandOutput} from "@aws-sdk/client-dynamodb";
 import {marshall, unmarshall} from "@aws-sdk/util-dynamodb";
 import {OnboardingTableItem} from "../@Types/OnboardingTableItem";
 
@@ -13,14 +13,24 @@ class DynamoClient {
 
     async put(item: OnboardingTableItem): Promise<PutItemCommandOutput> {
         const params  = {
-            TableName : this.tableName,
+            TableName: this.tableName,
             Item: marshall(item)
         };
         const command = new PutItemCommand(params);
         return await this.dynamodb.send(command);
     }
 
-    //async getByKey
+    async queryBySortKey(sortKey: string): Promise<QueryCommandOutput> {
+        const params = {
+            TableName: this.tableName,
+            IndexName: 'sk-index',
+            ExpressionAttributeValues: {":sortKey": {S: sortKey}},
+            KeyConditionExpression: "sk = :sortKey"
+        }
+        console.log(params);
+        const command = new QueryCommand(params);
+        return await this.dynamodb.send(command);
+    }
 }
 
 export default DynamoClient;

--- a/lambda/dynamo-api/src/handlers/get-user.ts
+++ b/lambda/dynamo-api/src/handlers/get-user.ts
@@ -1,0 +1,22 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import DynamoClient from "../client/DynamoClient";
+
+const tableName = process.env.SAMPLE_TABLE;
+const client = new DynamoClient(tableName as string);
+
+export const getUserHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const cognitoId = JSON.parse(event.body as string);
+
+    // Do whatever validation we want to do on the user
+
+    let response = {statusCode: 200, body: JSON.stringify("OK")};
+    await client
+        .queryBySortKey(cognitoId)
+        .then((queryCommandOutput) => {
+            response.statusCode = 200;
+            response.body = JSON.stringify(queryCommandOutput);
+        })
+        .catch((queryCommandOutput) => { console.error(queryCommandOutput); response.statusCode = 500; response.body = JSON.stringify(queryCommandOutput)});
+
+    return response;
+};

--- a/lambda/dynamo-api/src/handlers/put-service-user.ts
+++ b/lambda/dynamo-api/src/handlers/put-service-user.ts
@@ -18,6 +18,7 @@ export const putServiceUserHandler = async (event: APIGatewayProxyEvent, context
         pk: payload.service.pk,
         sk: payload.user.pk,
         data: payload.user.email,
+        role: 'admin',
         service_name: payload.service.service_name
     }
     let response = {statusCode: 200, body: JSON.stringify("OK")};

--- a/lambda/dynamo-api/src/handlers/put-service-user.ts
+++ b/lambda/dynamo-api/src/handlers/put-service-user.ts
@@ -9,20 +9,25 @@ import {PutItemCommandOutput} from "@aws-sdk/client-dynamodb";
 const tableName = process.env.SAMPLE_TABLE;
 const client = new DynamoClient(tableName as string);
 
-export const putServiceHandler = async (event: APIGatewayProxyEvent, context: Context): Promise<APIGatewayProxyResult> => {
+export const putServiceUserHandler = async (event: APIGatewayProxyEvent, context: Context): Promise<APIGatewayProxyResult> => {
     console.log("Received event:")
     console.log(event);
     console.log(context);
     const payload = event?.body ? JSON.parse(event.body as string) : event;
-
+    const record = {
+        pk: payload.service.pk,
+        sk: payload.user.pk,
+        data: payload.user.email,
+        service_name: payload.service.service_name
+    }
     let response = {statusCode: 200, body: JSON.stringify("OK")};
     await client
-        .put(payload.service)
+        .put(record)
         .then((putItemOutput) => {
             response.statusCode = 200;
             response.body = JSON.stringify(putItemOutput)
         })
-        .catch((putItemOutput) => { console.error(putItemOutput), response.statusCode = 500; response.body = JSON.stringify(putItemOutput)});
+        .catch((putItemOutput) => { response.statusCode = 500; response.body = JSON.stringify(putItemOutput)});
 
     return response;
 };

--- a/lambda/dynamo-api/src/state-machines/newService.json
+++ b/lambda/dynamo-api/src/state-machines/newService.json
@@ -1,0 +1,53 @@
+{
+  "Comment": "Put new service and service user record into DynamoDB by calling two different lambdas",
+  "StartAt": "Add service",
+  "States": {
+    "Add service": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$",
+      "Parameters": {
+        "FunctionName": "${PutServiceFunctionArn}",
+        "Payload.$": "$"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "ResultPath": "$.Payload",
+      "Next": "Add service user",
+      "Comment": "Finger crossed"
+    },
+    "Add service user": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$.Payload",
+      "Parameters": {
+        "FunctionName": "${PutServiceUserFunctionArn}",
+        "Payload.$": "$"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "End": true,
+      "Comment": "Finger crossed"
+    }
+  }
+}

--- a/lambda/dynamo-api/template-without-swagger.yaml
+++ b/lambda/dynamo-api/template-without-swagger.yaml
@@ -30,9 +30,6 @@ Resources:
           Properties:
             Path: /put-user
             Method: POST
-            RestApiId:
-              Ref: StepFunctionAPIGateway
-
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -64,9 +61,6 @@ Resources:
           Properties:
             Path: /get-user
             Method: POST
-            RestApiId:
-              Ref: StepFunctionAPIGateway
-
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -100,9 +94,6 @@ Resources:
           Properties:
             Path: /put-service
             Method: POST
-            RestApiId:
-              Ref: StepFunctionAPIGateway
-
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -136,9 +127,6 @@ Resources:
           Properties:
             Path: /put-service-user
             Method: POST
-            RestApiId:
-              Ref: StepFunctionAPIGateway
-
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -147,91 +135,6 @@ Resources:
         Sourcemap: true
         EntryPoints:
           - src/handlers/put-service-user.ts
-
-  StepFunctionAPIGateway:
-    Type: AWS::Serverless::Api
-    DependsOn:
-      - NewServiceStepFunction
-      - putUserFunction
-      - getUserFunction
-      - putServiceFunction
-      - putServiceUserFunction
-
-    Properties:
-      StageName: Prod
-      DefinitionBody:
-        swagger: "2.0"
-        info:
-          version: "1.0"
-          title: "dynamo-lambdas"
-        host: "hzs3irscf6.execute-api.eu-west-2.amazonaws.com"
-        basePath: "/Prod"
-        schemes:
-          - "https"
-        paths:
-          /get-user:
-            post:
-              responses: { }
-              x-amazon-apigateway-integration:
-                httpMethod: "POST"
-                uri:
-                  Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${getUserFunction.Arn}/invocations
-                passthroughBehavior: "when_no_match"
-                type: "aws_proxy"
-          /new-service:
-            post:
-              consumes:
-                - "application/json"
-              responses:
-                "200":
-                  description: "200 response"
-                "400":
-                  description: "400 response"
-              x-amazon-apigateway-integration:
-                credentials:
-                  Fn::Sub: arn:aws:iam::494650018671:role/${NewServiceStepFunctionApiRole}
-                httpMethod: "POST"
-                uri:
-                  Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution
-                responses:
-                  "200":
-                    statusCode: "200"
-                  "400":
-                    statusCode: "400"
-                requestTemplates:
-                  application/json:
-                    Fn::Sub:  "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\"\
-                    \\\\'\",\"'\")\", \"stateMachineArn\": \"${NewServiceStepFunction}\"\
-                    }"
-                passthroughBehavior: "when_no_match"
-                type: "aws"
-          /put-service:
-            post:
-              responses: { }
-              x-amazon-apigateway-integration:
-                httpMethod: "POST"
-                uri:
-                  Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${putServiceFunction.Arn}/invocations
-                passthroughBehavior: "when_no_match"
-                type: "aws_proxy"
-          /put-service-user:
-            post:
-              responses: { }
-              x-amazon-apigateway-integration:
-                httpMethod: "POST"
-                uri:
-                  Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${putServiceUserFunction.Arn}/invocations
-                passthroughBehavior: "when_no_match"
-                type: "aws_proxy"
-          /put-user:
-            post:
-              responses: { }
-              x-amazon-apigateway-integration:
-                httpMethod: "POST"
-                uri:
-                  Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${putUserFunction.Arn}/invocations
-                passthroughBehavior: "when_no_match"
-                type: "aws_proxy"
 
   NewServiceStepFunction:
     Type: AWS::Serverless::StateMachine
@@ -248,15 +151,14 @@ Resources:
             FunctionName:
               !Ref putServiceUserFunction
       Events:
-        Api:
-          Type: Api
-          Properties:
-            Path: /new-service
-            Method: Post
-            RestApiId:
-              Ref: StepFunctionAPIGateway
+        PostApi:
+          Api:
+            Type: Api
+            Properties:
+              Path: /new-service
+              Method: Post
 
 Outputs:
   WebEndpoint:
     Description: "API Gateway endpoint URL for Prod stage"
-    Value: !Sub "https://${StepFunctionAPIGateway}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"

--- a/lambda/dynamo-api/template.yaml
+++ b/lambda/dynamo-api/template.yaml
@@ -71,6 +71,22 @@ Resources:
         Sourcemap: true
         EntryPoints:
           - src/handlers/put-service.ts
+
+  NewServiceStepFunction:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      DefinitionUri: ./src/state-machines/newService.json
+      Policies:
+        - LambdaInvokePolicy:
+            FunctionName:
+              !Ref putServiceFunction
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /new-service
+            Method: Post
+
 Outputs:
   WebEndpoint:
     Description: "API Gateway endpoint URL for Prod stage"


### PR DESCRIPTION
Create lambda to save service
Create lambda to save service-user
Create StepFunction to co-ordinate the running of each of the above lambdas
Create API Gateway configuration to invoke StepFunction wihout JSON containing apostrophes being mangled by AWS into something AWS won't accept.
Create controller to handle the creation of a new service and to call the API Gateway Resource created above.
Keep template.yaml that didn't need a massive verbose API definition so I can shed a tear at how close we were to something elegant and simple.
Update sign-in controller to send us straight to the add-service screen because it's much easier to develop when you only have to sign in and not sign-up every try.
Add necessary functions to LambdaFacade
Add QueryBySortKey to DynamoClient on lambda side as we have to work with the secondary index to get our user by CognitoId
Add the get-user lambda because we need to retrieve the user we created.
