### PR TITLE
DFA-728 Store Client Details in DynamoDB

### DIFF
--- a/express/src/controllers/manage-account.ts
+++ b/express/src/controllers/manage-account.ts
@@ -36,7 +36,8 @@ export const processAddServiceForm = async function (req: Request, res: Response
     }
 
     let newServiceData = JSON.parse(newServiceOutput?.data.output);
-    const generatedClient = await lambdaFacade.generateClient(newServiceData.serviceId, service, newUser.email as string, req.session.authenticationResult?.AccessToken as string)
+    const generatedClient = await lambdaFacade.generateClient(newServiceData.serviceId, service, newUser.email as string, req.session.authenticationResult?.AccessToken as string);
+    console.debug(generatedClient);
     res.redirect("/service-dashboard-client-details");
 }
 

--- a/lambda/dynamo-api/src/handlers/put-client.ts
+++ b/lambda/dynamo-api/src/handlers/put-client.ts
@@ -1,25 +1,28 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import DynamoClient from "../client/DynamoClient";
+import {randomUUID} from "crypto";
 
 const tableName = process.env.SAMPLE_TABLE;
 const client = new DynamoClient(tableName as string);
 
 
 export const putClientHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-    const payload = JSON.parse(event.body as string);
-
+    const payload: any = JSON.parse((event as any).body);
+    console.log("Payload")
+    console.log(payload);
+    const clientId = `client#${randomUUID()}`;
     let record = {
-        pk: payload.clientId,
-        sk: payload.clientId,
-        data: payload.authClientId,
-        public_key: 'PUBLIC KEY',
-        redirect_uris: ['http://localhost/'],
-        contacts: [payload.contactEmail],
-        scopes: ['openid', 'email', 'phone'],
-        post_logout_redirect_uris: ['http://localhost/'],
-        subject_type: 'pairwise',
-        service_type: 'MANDATORY',
-        default_fields: ['data','redirect_uris','scopes','post_logout_redirect_uris','subject_type','service_type']
+        pk: clientId,
+        sk: clientId,
+        data: payload.client_id,
+        public_key: payload.public_key,
+        redirect_uris: payload.redirect_uris,
+        contacts: payload.contacts,
+        scopes: payload.scopes,
+        post_logout_redirect_uris: payload.post_logout_redirect_uris,
+        subject_type: payload.subject_type,
+        service_type: payload.service_type,
+        default_fields: ['data', 'public_key', 'redirect_uris','scopes','post_logout_redirect_uris','subject_type','service_type']
     };
 
     let response = {statusCode: 200, body: JSON.stringify("OK")};
@@ -27,7 +30,7 @@ export const putClientHandler = async (event: APIGatewayProxyEvent): Promise<API
         .put(record)
         .then((putItemOutput) => {
             response.statusCode = 200;
-            response.body = JSON.stringify(putItemOutput)
+            response.body = JSON.stringify({...record, ...payload});
         })
         .catch((putItemOutput) => { response.statusCode = 500; response.body = JSON.stringify(putItemOutput)});
 

--- a/lambda/dynamo-api/src/handlers/put-service-client.ts
+++ b/lambda/dynamo-api/src/handlers/put-service-client.ts
@@ -6,12 +6,11 @@ const client = new DynamoClient(tableName as string);
 
 
 export const putServiceClientHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-    const payload = JSON.parse(event.body as string);
-
+    const payload = JSON.parse((event as any).body as string);
     let record = {
-        pk: payload.serviceId,
-        sk: payload.clientId,
-        data: `${payload.serviceName} test client`,
+        pk: payload.service.pk,
+        sk: payload.pk,
+        data: payload.service.service_name,
         type: 'integration'
     };
 
@@ -20,9 +19,11 @@ export const putServiceClientHandler = async (event: APIGatewayProxyEvent): Prom
         .put(record)
         .then((putItemOutput) => {
             response.statusCode = 200;
-            response.body = JSON.stringify(putItemOutput)
+            response.body = JSON.stringify(payload);
         })
-        .catch((putItemOutput) => { response.statusCode = 500; response.body = JSON.stringify(putItemOutput)});
+        .catch((putItemOutput) => {
+            console.log(putItemOutput)
+            response.statusCode = 500; response.body = JSON.stringify(putItemOutput)});
 
     return response;
 };

--- a/lambda/dynamo-api/src/handlers/register-client.ts
+++ b/lambda/dynamo-api/src/handlers/register-client.ts
@@ -20,26 +20,33 @@ export const registerClientHandler = async (event: APIGatewayProxyEvent): Promis
     console.log("Payload")
     console.log(payload)
 
+    const public_key = 'MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAp2mLkQGo24Kz1rut0oZlviMkGomlQCH+iT1pFvegZFXq39NPjRWyatmXp/XIUPqCq9Kk8/+tq4Sgjw+EM5tATJ06j5r+35of58ATGVPniW//IhGizrv6/ebGcGEUJ0Y/ZmlCHYPV+lbewpttQ/IYKM1nr3k/Rl6qepbVYe+MpGubluQvdhgUYel9OzxiOvUk7XI0axPquiXzoEgmNNOai8+WhYTkBqE3/OucAv+XwXdnx4XHmKzMwTv93dYMpUmvTxWcSeEJ/4/SrbiK4PyHWVKU2BozfSUejVNhahAzZeyyDwhYJmhBaZi/3eOOlqGXj9UdkOXbl3vcwBH8wD30O9/4F5ERLKxzOaMnKZ+RpnygWF0qFhf+UeFMy+O06sdgiaFnXaSCsIy/SohspkKiLjNnhvrDNmPLMQbQKQlJdcp6zUzI7Gzys7luEmOxyMpA32lDBQcjL7KNwM15s4ytfrJ46XEPZUXESce2gj6NazcPPsrTa/Q2+oLS9GWupGh7AgMBAAE=';
+    const redirect_uris = ['http://localhost/'];
+    const scopes = ['openid', 'email', 'phone'];
+    const post_logout_redirect_uris = ['http://localhost/'];
+    const subject_type = 'pairwise';
+    const service_type = 'MANDATORY';
+    const sector_identifier_uri = 'http://localhost/';
+
     let clientConfig = {
         client_name: payload.service.service_name,
-        public_key: 'MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAp2mLkQGo24Kz1rut0oZlviMkGomlQCH+iT1pFvegZFXq39NPjRWyatmXp/XIUPqCq9Kk8/+tq4Sgjw+EM5tATJ06j5r+35of58ATGVPniW//IhGizrv6/ebGcGEUJ0Y/ZmlCHYPV+lbewpttQ/IYKM1nr3k/Rl6qepbVYe+MpGubluQvdhgUYel9OzxiOvUk7XI0axPquiXzoEgmNNOai8+WhYTkBqE3/OucAv+XwXdnx4XHmKzMwTv93dYMpUmvTxWcSeEJ/4/SrbiK4PyHWVKU2BozfSUejVNhahAzZeyyDwhYJmhBaZi/3eOOlqGXj9UdkOXbl3vcwBH8wD30O9/4F5ERLKxzOaMnKZ+RpnygWF0qFhf+UeFMy+O06sdgiaFnXaSCsIy/SohspkKiLjNnhvrDNmPLMQbQKQlJdcp6zUzI7Gzys7luEmOxyMpA32lDBQcjL7KNwM15s4ytfrJ46XEPZUXESce2gj6NazcPPsrTa/Q2+oLS9GWupGh7AgMBAAE=',
-        redirect_uris: ['http://localhost/'],
+        public_key: public_key,
+        redirect_uris: redirect_uris,
         contacts: [payload.contactEmail],
-        scopes: ['openid', 'email', 'phone'],
-        post_logout_redirect_uris: ['http://localhost/'],
-        subject_type: 'pairwise',
-        service_type: 'MANDATORY',
-        sector_identifier_uri: 'http://localhost/'
+        scopes: scopes,
+        post_logout_redirect_uris: post_logout_redirect_uris,
+        subject_type: subject_type,
+        service_type: service_type,
+        sector_identifier_uri: sector_identifier_uri
     }
-    console.log("About to use Axios with payload of");
-    console.log(clientConfig);
     const result = await (await instance).post("/connect/register", JSON.stringify(clientConfig));
+    const body = {...clientConfig, ...result.data, ...payload};
+    console.log("The result was: " + JSON.stringify(body));
 
-    console.log("The result was: " + JSON.stringify(result.data));
 
     const response: APIGatewayProxyResult = {
         statusCode: 200,
-        body: JSON.stringify(result.data)
+        body: JSON.stringify(body)
     }
     return response;
 }

--- a/lambda/dynamo-api/template.yaml
+++ b/lambda/dynamo-api/template.yaml
@@ -145,7 +145,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: src/handlers/put-client.putClientHandler
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Architectures:
         - x86_64
       MemorySize: 128


### PR DESCRIPTION
The data pushed in and out of the lambdas can be refactored neatly and the step function transformations can be used so that only the necessary payloads are passed in.  For the sake of speed this hasn't been done but will definitely need to be refactored at a later date.

Modify register-client.ts lambda to use correct parts of payload when calling Auth API Endpoint. Pass on enough information to put-client for save to DDB to be successful
Modify put-client to take the correct things from input and save to DDB.  Return enough information for next put-service-client.ts lambda to be successful
Modufy put-service-client lambda to store the correct information in DDB.
Modify template.yaml - have putClientFunction use nodejs16.x so that randomUuid is available in the runtime
Modify manage-account controller to log the output of generateClient