### PR TITLE
DFA-949 Stop using client-client

### DIFF
--- a/lambda/dynamo-api/src/handlers/put-service-client.ts
+++ b/lambda/dynamo-api/src/handlers/put-service-client.ts
@@ -1,17 +1,29 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import DynamoClient from "../client/DynamoClient";
+import {randomUUID} from "crypto";
 
 const tableName = process.env.SAMPLE_TABLE;
 const client = new DynamoClient(tableName as string);
 
 
 export const putServiceClientHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-    const payload = JSON.parse((event as any).body as string);
+    const payload = JSON.parse(event.body as string);
+    console.log(payload)
+    const clientId = `client#${randomUUID()}`;
     let record = {
         pk: payload.service.pk,
-        sk: payload.pk,
+        sk: clientId,
         data: payload.service.service_name,
-        type: 'integration'
+        clientId: payload.client_id,
+        type: 'integration',
+        public_key: payload.public_key,
+        redirect_uris: payload.redirect_uris,
+        contacts: payload.contacts,
+        scopes: payload.scopes,
+        post_logout_redirect_uris: payload.post_logout_redirect_uris,
+        subject_type: payload.subject_type,
+        service_type: payload.service_type,
+        default_fields: ['data', 'public_key', 'redirect_uris','scopes','post_logout_redirect_uris','subject_type','service_type']
     };
 
     let response = {statusCode: 200, body: JSON.stringify("OK")};

--- a/lambda/dynamo-api/src/handlers/register-client.ts
+++ b/lambda/dynamo-api/src/handlers/register-client.ts
@@ -17,8 +17,6 @@ export const registerClientHandler = async (event: APIGatewayProxyEvent): Promis
     console.log(process.env.AUTH_REGISTRATION_BASE_URL)
 
     let payload: any = event;
-    console.log("Payload")
-    console.log(payload)
 
     const public_key = 'MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAp2mLkQGo24Kz1rut0oZlviMkGomlQCH+iT1pFvegZFXq39NPjRWyatmXp/XIUPqCq9Kk8/+tq4Sgjw+EM5tATJ06j5r+35of58ATGVPniW//IhGizrv6/ebGcGEUJ0Y/ZmlCHYPV+lbewpttQ/IYKM1nr3k/Rl6qepbVYe+MpGubluQvdhgUYel9OzxiOvUk7XI0axPquiXzoEgmNNOai8+WhYTkBqE3/OucAv+XwXdnx4XHmKzMwTv93dYMpUmvTxWcSeEJ/4/SrbiK4PyHWVKU2BozfSUejVNhahAzZeyyDwhYJmhBaZi/3eOOlqGXj9UdkOXbl3vcwBH8wD30O9/4F5ERLKxzOaMnKZ+RpnygWF0qFhf+UeFMy+O06sdgiaFnXaSCsIy/SohspkKiLjNnhvrDNmPLMQbQKQlJdcp6zUzI7Gzys7luEmOxyMpA32lDBQcjL7KNwM15s4ytfrJ46XEPZUXESce2gj6NazcPPsrTa/Q2+oLS9GWupGh7AgMBAAE=';
     const redirect_uris = ['http://localhost/'];
@@ -32,7 +30,7 @@ export const registerClientHandler = async (event: APIGatewayProxyEvent): Promis
         client_name: payload.service.service_name,
         public_key: public_key,
         redirect_uris: redirect_uris,
-        contacts: [payload.contactEmail],
+        contacts: [payload.contactEmail, "onboarding@digital.cabinet-office.gov.uk"],
         scopes: scopes,
         post_logout_redirect_uris: post_logout_redirect_uris,
         subject_type: subject_type,
@@ -41,8 +39,6 @@ export const registerClientHandler = async (event: APIGatewayProxyEvent): Promis
     }
     const result = await (await instance).post("/connect/register", JSON.stringify(clientConfig));
     const body = {...clientConfig, ...result.data, ...payload};
-    console.log("The result was: " + JSON.stringify(body));
-
 
     const response: APIGatewayProxyResult = {
         statusCode: 200,

--- a/lambda/dynamo-api/src/state-machines/newClient.json
+++ b/lambda/dynamo-api/src/state-machines/newClient.json
@@ -23,33 +23,10 @@
           "BackoffRate": 2
         }
       ],
-      "Next": "Put client",
+      "Next": "Put service client",
       "Comment": "Registers client with Auth"
     },
 
-    "Put client": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::lambda:invoke",
-      "OutputPath": "$.Payload",
-      "Parameters": {
-        "FunctionName": "${PutClientFunctionArn}",
-        "Payload.$": "$"
-      },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.AWSLambdaException",
-            "Lambda.SdkClientException"
-          ],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 6,
-          "BackoffRate": 2
-        }
-      ],
-      "Next": "Put service client",
-      "Comment": "Adds client to DDB"
-    },
 
     "Put service client": {
       "Type": "Task",

--- a/lambda/dynamo-api/template.yaml
+++ b/lambda/dynamo-api/template.yaml
@@ -141,33 +141,6 @@ Resources:
         EntryPoints:
           - src/handlers/register-client.ts
 
-  putClientFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: src/handlers/put-client.putClientHandler
-      Runtime: nodejs16.x
-      Architectures:
-        - x86_64
-      MemorySize: 128
-      Timeout: 100
-      Description: A simple example includes a HTTP post method to add a service to a DynamoDB table.
-      Policies:
-        # Give Create/Read/Update/Delete Permissions to the SampleTable
-        - DynamoDBCrudPolicy:
-            TableName: 'onboarding'
-      Environment:
-        Variables:
-          # Make table name accessible as environment variable from function code during execution
-          SAMPLE_TABLE: 'onboarding'
-    Metadata:
-      BuildMethod: esbuild
-      BuildProperties:
-        Minify: true
-        Target: "es2020"
-        Sourcemap: true
-        EntryPoints:
-          - src/handlers/put-client.ts
-
   putServiceClientFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -353,7 +326,6 @@ Resources:
                   - !GetAtt putServiceFunction.Arn
                   - !GetAtt putServiceUserFunction.Arn
                   - !GetAtt registerClientFunction.Arn
-                  - !GetAtt putClientFunction.Arn
                   - !GetAtt putServiceClientFunction.Arn
 
   NewServiceStepFunction:
@@ -396,7 +368,6 @@ Resources:
       DefinitionUri: ./src/state-machines/newClient.json
       DefinitionSubstitutions:
         RegisterClientFunctionArn: !GetAtt registerClientFunction.Arn
-        PutClientFunctionArn: !GetAtt putClientFunction.Arn
         PutServiceClientFunctionArn: !GetAtt putServiceClientFunction.Arn
 
   StepFunctionsLogGroup:


### PR DESCRIPTION
Database needs to hold different data because dashboard displays all clients per service.

Remove client-client records - remove put-client lambda.  Update put-service-client to include service details.
Update state machine for new client
Update template.yaml

Would be good to review structure of new service-client record in development account DDB.