### PR TITLE
Dfa 940 get services for user lambda

### DIFF
--- a/lambda/dynamo-api/src/client/DynamoClient.ts
+++ b/lambda/dynamo-api/src/client/DynamoClient.ts
@@ -23,7 +23,7 @@ class DynamoClient {
     async queryBySortKey(sortKey: string): Promise<QueryCommandOutput> {
         const params = {
             TableName: this.tableName,
-            IndexName: 'sk-index',
+            IndexName: 'gsi1',
             ExpressionAttributeValues: {":sortKey": {S: sortKey}},
             KeyConditionExpression: "sk = :sortKey"
         }
@@ -32,12 +32,13 @@ class DynamoClient {
         return await this.dynamodb.send(command);
     }
 
-    async queryBySortKeyAndUnmarshal(sortKey: string): Promise<QueryCommandOutput> {
+    async getServices(userId: string): Promise<QueryCommandOutput> {
         const params = {
             TableName: this.tableName,
-            IndexName: 'sk-index',
-            ExpressionAttributeValues: {":sortKey": {S: sortKey}},
-            KeyConditionExpression: "sk = :sortKey"
+            IndexName: 'gsi1',
+            ExpressionAttributeNames: {"#userId": "sk", "#serviceId": "pk"},
+            ExpressionAttributeValues: {":userId": {S: `user#${userId}`}, ":serviceIdPrefix": {S: "service#"}},
+            KeyConditionExpression: "#userId = :userId AND begins_with ( #serviceId, :serviceIdPrefix )"
         }
         console.log(params);
         const command = new QueryCommand(params);

--- a/lambda/dynamo-api/src/handlers/get-services.ts
+++ b/lambda/dynamo-api/src/handlers/get-services.ts
@@ -1,0 +1,27 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import DynamoClient from "../client/DynamoClient";
+
+const tableName = process.env.TABLE;
+const client = new DynamoClient(tableName as string);
+
+
+export const getServicesHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const userId = event.pathParameters?.userId;
+    if(userId === undefined) {
+        return noUserIdResponse;
+    }
+
+    let response = {statusCode: 200, body: JSON.stringify(userId)};
+    await client.getServices(userId)
+        .then((queryCommandOutput) => {
+            response.statusCode = 200;
+            response.body = JSON.stringify(queryCommandOutput);
+        })
+        .catch((queryCommandOutput) => { console.error(queryCommandOutput); response.statusCode = 500; response.body = JSON.stringify(queryCommandOutput)});
+
+    return response;
+};
+
+const noUserIdResponse = {
+    statusCode: 400, body: JSON.stringify("No userId request parameter supplied")
+};

--- a/lambda/dynamo-api/src/handlers/register-client.ts
+++ b/lambda/dynamo-api/src/handlers/register-client.ts
@@ -37,6 +37,7 @@ export const registerClientHandler = async (event: APIGatewayProxyEvent): Promis
         service_type: service_type,
         sector_identifier_uri: sector_identifier_uri
     }
+
     const result = await (await instance).post("/connect/register", JSON.stringify(clientConfig));
     const body = {...clientConfig, ...result.data, ...payload};
 

--- a/lambda/dynamo-api/template.yaml
+++ b/lambda/dynamo-api/template.yaml
@@ -111,6 +111,40 @@ Resources:
         EntryPoints:
           - src/handlers/put-service.ts
 
+  getServicesFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/get-services.getServicesHandler
+      Runtime: nodejs16.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 100
+      Description: Return services related to a given userId.
+      Policies:
+        # Give Create/Read/Update/Delete Permissions to the SampleTable
+        - DynamoDBCrudPolicy:
+            TableName: 'onboarding'
+      Environment:
+        Variables:
+          TABLE: 'onboarding'
+
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Path: /get-services/{userId}
+            Method: GET
+
+    Metadata: # Manage esbuild properties
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2020"
+        Sourcemap: true
+        EntryPoints:
+          - src/handlers/get-services.ts
+
   registerClientFunction:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
This is branched off DFA-949 because time and tide wait don't wait and neither do I.  Once that's merged this can be rebased etc.

Lambda to query DynamoDB for all services associated with a given user and return as an array of items.

Update DynamoClient with getServices(userId: string) method.  DynamoDB parameters used include ExpressionAttriubteNames to make the whole `pk` and `sk` thing a little less confusing - we create aliases to explain what they represent in this context.

Delete redundant method that promised to marshal a result but did no such thing.

Implement getServiceHandler lamdba.  Return useful 400 response if no userId provided.  In practice I don't think the lambda gets called if the parameter is missing but the thought is there.

Update template.yaml to deploy new lambda.