### PR TITLE
DFA-943 list services controller route and view

### DIFF
--- a/express/@types/User/index.d.ts
+++ b/express/@types/User/index.d.ts
@@ -1,5 +1,5 @@
 export interface User {
-    [id | pk]: string;
+    pk: {S: string};
     [cognitoId | sk]: string;
     data: string;
     [firstName | first_name]: string | undefined;

--- a/express/src/controllers/manage-account.ts
+++ b/express/src/controllers/manage-account.ts
@@ -55,7 +55,9 @@ export const processAddServiceForm = async function (req: Request, res: Response
 
     let newServiceData = JSON.parse(newServiceOutput?.data.output);
     const generatedClient = await lambdaFacade.generateClient(newServiceData.serviceId, service, newUser.email as string, req.session.authenticationResult?.AccessToken as string)
-    const clientId = JSON.parse(generatedClient.data.output.body).clientId;
+    const body = JSON.parse(generatedClient.data.output).body;
+    const clientId = JSON.parse(body).clientId;
+
     res.redirect(`/client-details/${clientId}`);
 }
 

--- a/express/src/controllers/manage-account.ts
+++ b/express/src/controllers/manage-account.ts
@@ -5,12 +5,30 @@ import {User} from "../../@types/User";
 import {Service} from "../../@types/Service";
 
 export const listServices = async function(req: Request, res: Response) {
-    res.render('manage-account/list-services.njk');
+    const lambdaFacade: LambdaFacadeInterface = req.app.get("lambdaFacade");
+    if(req.session.selfServiceUser == undefined) {
+        res.render('there-is-a-problem.njk');
+        return;
+    }
+    const user: User = req.session.selfServiceUser;
+    const services = await lambdaFacade.listServices(user.pk.S as string, req.session.authenticationResult?.AccessToken as string);
+    if(services.data.Items.length === 0) {
+        res.redirect('/add-service-name');
+        return;
+    }
+    console.log(services.data.Items);
+    if(services.data.Items.length === 1) {
+        res.redirect(`/service-dashboard-client-details/${services.data.Items[0].pk.S.substring(8)}`);
+        return;
+    }
+
+    res.render('manage-account/list-services.njk', {services: services.data.Items});
 }
 
 export const showAddServiceForm = async function (req: Request, res: Response) {
     res.render("add-service-name.njk");
 }
+
 export const processAddServiceForm = async function (req: Request, res: Response) {
     const uuid = randomUUID();
     const service: Service = {
@@ -36,11 +54,9 @@ export const processAddServiceForm = async function (req: Request, res: Response
     }
 
     let newServiceData = JSON.parse(newServiceOutput?.data.output);
-    const generatedClient = await lambdaFacade.generateClient(newServiceData.serviceId, service, newUser.email as string, req.session.authenticationResult?.AccessToken as string);
-    console.debug(generatedClient);
-    res.redirect("/service-dashboard-client-details");
+    const generatedClient = await lambdaFacade.generateClient(newServiceData.serviceId, service, newUser.email as string, req.session.authenticationResult?.AccessToken as string)
+    const clientId = JSON.parse(generatedClient.data.output.body).clientId;
+    res.redirect(`/client-details/${clientId}`);
 }
 
-export const generateClient = async function (req: Request, res: Response) {
 
-}

--- a/express/src/controllers/sign-in.ts
+++ b/express/src/controllers/sign-in.ts
@@ -26,7 +26,7 @@ export const showLoginOtpMobile = async function(req: Request, res: Response) {
 
 export const processLoginOtpMobile = async function(req: Request, res: Response) {
     // TO DO add the functionality to process the login mobile otp
-    res.redirect('/add-service-name');
+    res.redirect('/account/list-services');
 }
 
 export const processEmailAddress = async function (req: Request, res: Response) {

--- a/express/src/lib/lambda-facade/LambdaFacade.ts
+++ b/express/src/lib/lambda-facade/LambdaFacade.ts
@@ -58,5 +58,10 @@ class LambdaFacade implements LambdaFacadeInterface {
             }
         });
     }
+
+    async listServices(userId: string, accessToken: string): Promise<AxiosResponse> {
+        const bareUserId = userId.substring(5);
+        return await (await this.instance).get(`/Prod/get-services/${bareUserId}`);
+    }
 }
 export const lambdaFacadeInstance = new LambdaFacade(process.env.API_BASE_URL as string);

--- a/express/src/lib/lambda-facade/LambdaFacadeInterface.ts
+++ b/express/src/lib/lambda-facade/LambdaFacadeInterface.ts
@@ -9,4 +9,5 @@ export default interface LambdaFacadeInterface {
     getUserByCognitoId(cognitoId: string, accessToken: string): Promise<AxiosResponse>;
     newService(service: Service, user: User, accessToken: string): Promise<AxiosResponse>;
     generateClient(serviceId: string, service: Service, contactEmail: string, accessToken: string): Promise<AxiosResponse>;
+    listServices(userId: string, accessToken: string): Promise<AxiosResponse>;
 }

--- a/express/src/lib/lambda-facade/StubLambdaFacade.ts
+++ b/express/src/lib/lambda-facade/StubLambdaFacade.ts
@@ -27,5 +27,9 @@ class StubLambdaFacade implements LambdaFacadeInterface {
     generateClient(serviceId: string, service: Service, contactEmail: string, accessToken: string): Promise<AxiosResponse> {
         return Promise.resolve({} as AxiosResponse);
     }
+
+    listServices(userId: string, accessToken: string): Promise<AxiosResponse> {
+        return Promise.resolve({} as AxiosResponse);
+    }
 }
 export const lambdaFacadeInstance = new StubLambdaFacade();

--- a/express/src/routes/manage-account.ts
+++ b/express/src/routes/manage-account.ts
@@ -10,7 +10,7 @@ router.get('/account/list-services', checkAuthorisation, listServices);
 router.get('/add-service-name', checkAuthorisation, showAddServiceForm);
 router.post('/create-service-name-validation', checkAuthorisation, serviceNameValidator, processAddServiceForm);
 
-router.get('/client-details', (req, res) => {
+router.get('/client-details/:serviceId', (req, res) => {
     res.render("client-details.njk", {
         publicKeyAndUrlsNotUpdatedByUser: true,
         userDetailsUpdated: false,

--- a/express/src/views/manage-account/list-services.njk
+++ b/express/src/views/manage-account/list-services.njk
@@ -1,9 +1,20 @@
 {% extends '../layout.njk' %}
 
 {% block content %}
-<div class="govuk-width-container">
-    <h1 class="govuk-heading-xl">
-        You shouldn't be able to see this!
-    </h1>
-</div>
+    <div class="govuk-width-container">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+
+                <h1 class="govuk-heading-xl">
+                    Your services
+                </h1>
+                {% for service in services %}
+                    <p>
+                        <a class="govuk-body"
+                           href="/service-dashboard-client-details/{{ service.pk.S.substring(8) }}/">{{ service.service_name.S }}</a>
+                    </p>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
 {% endblock %}

--- a/lambda/dynamo-api/src/handlers/put-service-client.ts
+++ b/lambda/dynamo-api/src/handlers/put-service-client.ts
@@ -31,7 +31,7 @@ export const putServiceClientHandler = async (event: APIGatewayProxyEvent): Prom
         .put(record)
         .then((putItemOutput) => {
             response.statusCode = 200;
-            response.body = JSON.stringify(payload);
+            response.body = JSON.stringify(record)
         })
         .catch((putItemOutput) => {
             console.log(putItemOutput)


### PR DESCRIPTION
 A user logging in will be shown a list of their services unless; they only have one in which case they'll be taken straight to the client screen; they don't have any in which case they'll be taken to the create service screen.
    
Modify User type - this is to get things working.  We should review everything and figure out where we do our unmarshalling - I expect the answer is in the DDB client.

Modify manage-accounts.ts controllers file.
* List services controller with basic conditional logic to determine whether services are listed, a new one must be created or clients are displayed.
* Extract (our) Client ID from generated client and append to redirect path as parameter.

Modify sign-in.ts - redirect to /account/list-services

Modify Lamdba Facade interface and implementations - add `listServices(userId: string, accessToken: string)`

Modify routes/manage-accounts.ts - add path parameter to `/service-client-details`

Modify / create super basic place-holder list services page.

Modify put-service-client.ts to return record that was inserted instead of response from DynamoDB

