### PR TITLE
DFA-968 stack for DynamoDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,4 +105,5 @@ dist
 
 .idea/
 **/*.iml
-*/.aws-sam
+**/.aws-sam
+**/*samconfig.toml

--- a/backend/dynamo-api/deploy-script.sh
+++ b/backend/dynamo-api/deploy-script.sh
@@ -16,7 +16,7 @@ then
 fi
 osascript -e 'say "Yipee! We managed to build it!"'
 
-if ! gds aws di-onboarding-development -- sam deploy --parameter-overrides "AuthRegistrationBaseUrl=https://oidc.integration.account.gov.uk"
+if ! gds aws di-onboarding-development -- sam deploy --parameter-overrides "AuthRegistrationBaseUrl=https://oidc.integration.account.gov.uk DynamoDbTableStackName=dynamo-db-stack"
 then
   osascript -e 'say "Oh no, it did not deploy!"'
   exit

--- a/backend/dynamo-api/template.yaml
+++ b/backend/dynamo-api/template.yaml
@@ -574,6 +574,6 @@ Resources:
     Type: AWS::Logs::LogGroup
 
 Outputs:
-  WebEndpoint:
-    Description: "API Gateway endpoint URL for Prod stage"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+  ApiBaseUrl:
+    Description: "API base URL - URL used by epxress frontend - supplied as an env var."
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com"

--- a/backend/dynamo-api/template.yaml
+++ b/backend/dynamo-api/template.yaml
@@ -575,5 +575,5 @@ Resources:
 
 Outputs:
   ApiBaseUrl:
-    Description: "API base URL - URL used by epxress frontend - supplied as an env var."
+    Description: "API base URL - URL used by Express frontend - supplied as an env var."
     Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com"

--- a/backend/dynamo-api/template.yaml
+++ b/backend/dynamo-api/template.yaml
@@ -8,6 +8,9 @@ Parameters:
   AuthRegistrationBaseUrl:
     Type: String
     Description: API Gateway endpoint for client registration
+  DynamoDbTableStackName:
+    Type: String
+    Description: The name of the stack exporting the table we want
 
 Resources:
 
@@ -22,13 +25,13 @@ Resources:
       Timeout: 100
       Description: A simple example includes a HTTP post method to add one item to a DynamoDB table.
       Policies:
-        # Give Create/Read/Update/Delete Permissions to the SampleTable
         - DynamoDBCrudPolicy:
-            TableName: 'onboarding'
+            TableName: !ImportValue
+              'Fn::Sub': '${DynamoDbTableStackName}-Self-Service-table'
       Environment:
         Variables:
-          # Make table name accessible as environment variable from function code during execution
-          TABLE: 'onboarding'
+          TABLE: !ImportValue
+                   'Fn::Sub': '${DynamoDbTableStackName}-Self-Service-table'
       Events:
         Api:
           Type: Api
@@ -57,10 +60,12 @@ Resources:
       Description: Retrieve a user item from the table.
       Policies:
         - DynamoDBCrudPolicy:
-            TableName: 'onboarding'
+            TableName: !ImportValue
+              'Fn::Sub': '${DynamoDbTableStackName}-Self-Service-table'
       Environment:
         Variables:
-          TABLE: 'onboarding'
+          TABLE: !ImportValue
+            'Fn::Sub': '${DynamoDbTableStackName}-Self-Service-table'
       Events:
         Api:
           Type: Api
@@ -88,13 +93,13 @@ Resources:
       Timeout: 100
       Description: A simple example includes a HTTP post method to add a service to a DynamoDB table.
       Policies:
-        # Give Create/Read/Update/Delete Permissions to the SampleTable
         - DynamoDBCrudPolicy:
-            TableName: 'onboarding'
+            TableName: !ImportValue
+              'Fn::Sub': '${DynamoDbTableStackName}-Self-Service-table'
       Environment:
         Variables:
-          # Make table name accessible as environment variable from function code during execution
-          TABLE: 'onboarding'
+          TABLE: !ImportValue
+            'Fn::Sub': '${DynamoDbTableStackName}-Self-Service-table'
       Events:
         Api:
           Type: Api
@@ -122,12 +127,13 @@ Resources:
       Timeout: 100
       Description: Return services related to a given userId.
       Policies:
-        # Give Create/Read/Update/Delete Permissions to the SampleTable
         - DynamoDBCrudPolicy:
-            TableName: 'onboarding'
+            TableName: !ImportValue
+              'Fn::Sub': '${DynamoDbTableStackName}-Self-Service-table'
       Environment:
         Variables:
-          TABLE: 'onboarding'
+          TABLE: !ImportValue
+            'Fn::Sub': '${DynamoDbTableStackName}-Self-Service-table'
 
       Events:
         Api:
@@ -157,10 +163,12 @@ Resources:
       Description: Return services related to a given userId.
       Policies:
         - DynamoDBCrudPolicy:
-            TableName: 'onboarding'
+            TableName: !ImportValue
+              'Fn::Sub': '${DynamoDbTableStackName}-Self-Service-table'
       Environment:
         Variables:
-          TABLE: 'onboarding'
+          TABLE: !ImportValue
+            'Fn::Sub': '${DynamoDbTableStackName}-Self-Service-table'
 
       Events:
         Api:
@@ -249,13 +257,13 @@ Resources:
       Timeout: 100
       Description: A simple example includes a HTTP post method to add a service to a DynamoDB table.
       Policies:
-        # Give Create/Read/Update/Delete Permissions to the SampleTable
         - DynamoDBCrudPolicy:
-            TableName: 'onboarding'
+            TableName: !ImportValue
+              'Fn::Sub': '${DynamoDbTableStackName}-Self-Service-table'
       Environment:
         Variables:
-          # Make table name accessible as environment variable from function code during execution
-          TABLE: 'onboarding'
+          TABLE: !ImportValue
+            'Fn::Sub': '${DynamoDbTableStackName}-Self-Service-table'
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -276,13 +284,13 @@ Resources:
       Timeout: 100
       Description: Update service client in DDB.
       Policies:
-        # Give Create/Read/Update/Delete Permissions to the SampleTable
         - DynamoDBCrudPolicy:
-            TableName: 'onboarding'
+            TableName: !ImportValue
+              'Fn::Sub': '${DynamoDbTableStackName}-Self-Service-table'
       Environment:
         Variables:
-          # Make table name accessible as environment variable from function code during execution
-          TABLE: 'onboarding'
+          TABLE: !ImportValue
+            'Fn::Sub': '${DynamoDbTableStackName}-Self-Service-table'
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -303,13 +311,13 @@ Resources:
       Timeout: 100
       Description: A simple example includes a HTTP post method to add a service to a DynamoDB table.
       Policies:
-        # Give Create/Read/Update/Delete Permissions to the SampleTable
         - DynamoDBCrudPolicy:
-            TableName: 'onboarding'
+            TableName: !ImportValue
+              'Fn::Sub': '${DynamoDbTableStackName}-Self-Service-table'
       Environment:
         Variables:
-          # Make table name accessible as environment variable from function code during execution
-          TABLE: 'onboarding'
+          TABLE: !ImportValue
+            'Fn::Sub': '${DynamoDbTableStackName}-Self-Service-table'
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:

--- a/backend/dynamo-db/template.yaml
+++ b/backend/dynamo-db/template.yaml
@@ -4,11 +4,6 @@ Description: >-
 Transform:
   - AWS::Serverless-2016-10-31
 
-Parameters:
-  AuthRegistrationBaseUrl:
-    Type: String
-    Description: API Gateway endpoint for client registration
-
 Resources:
   Table:
     Type: AWS::DynamoDB::Table
@@ -29,11 +24,7 @@ Resources:
           AttributeName: sk
           KeyType: RANGE
 
-      BillingMode: PROVISIONED
-
-      ProvisionedThroughput:
-        ReadCapacityUnits: 1
-        WriteCapacityUnits: 1
+      BillingMode: PAY_PER_REQUEST
 
       GlobalSecondaryIndexes:
         -
@@ -47,9 +38,6 @@ Resources:
               KeyType: RANGE
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            ReadCapacityUnits: 1
-            WriteCapacityUnits: 1
 
 Outputs:
   TableName:

--- a/lambda/dynamo-db/template.yaml
+++ b/lambda/dynamo-db/template.yaml
@@ -1,0 +1,59 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  DynaomDB table for di-onboarding-self-service-experience
+Transform:
+  - AWS::Serverless-2016-10-31
+
+Parameters:
+  AuthRegistrationBaseUrl:
+    Type: String
+    Description: API Gateway endpoint for client registration
+
+Resources:
+  Table:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableClass: STANDARD
+      AttributeDefinitions:
+        -
+          AttributeName: pk
+          AttributeType: S
+        -
+          AttributeName: sk
+          AttributeType: S
+      KeySchema:
+        -
+          AttributeName: pk
+          KeyType: HASH
+        -
+          AttributeName: sk
+          KeyType: RANGE
+
+      BillingMode: PROVISIONED
+
+      ProvisionedThroughput:
+        ReadCapacityUnits: 1
+        WriteCapacityUnits: 1
+
+      GlobalSecondaryIndexes:
+        -
+          IndexName: gsi1
+          KeySchema:
+            -
+              AttributeName: sk
+              KeyType: HASH
+            -
+              AttributeName: pk
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: 1
+            WriteCapacityUnits: 1
+
+Outputs:
+  TableName:
+    Description: TableName generated for this stack
+    Value: !Ref Table
+    Export:
+      Name: !Sub "${AWS::StackName}-Self-Service-table"


### PR DESCRIPTION
Write a template so the correct database table can be deployed to all environments.

Export table name - use stack name as part of export to namespace the tables.

Update lambdas to import the table name and use it.

See commits.