### PR TITLE
DFA-914 Change user attributes

### DIFF
--- a/express/src/routes/manage-account.ts
+++ b/express/src/routes/manage-account.ts
@@ -27,24 +27,20 @@ router.get('/client-details/:serviceId', async (req, res) => {
         clientName: client.data,
         serviceName: client.service_name,
         clientId: client.clientId,
-        redirectUrls: arraysToString(client.redirect_uris),
-        userAttributesRequired: arraysToString(client.scopes),
+        redirectUrls: client.redirect_uris.join(" "),
+        userAttributesRequired: client.scopes.join(", "),
         userPublicKey: client.public_key == DEFAULT_PUBLIC_KEY ? "" : client.public_key,
-        postLogoutRedirectUrls: arraysToString(client.post_logout_redirect_uris),
+        postLogoutRedirectUrls: client.post_logout_redirect_uris.join(" "),
         urls: {
             changeClientName: `/change-client-name/${serviceId}/${selfServiceClientId}/${authClientId}?clientName=${encodeURI(client.data)}`,
-            changeRedirectUris: `/change-redirect-URIs/${serviceId}/${selfServiceClientId}/${authClientId}?redirectUris=${encodeURI(arraysToString(client.redirect_uris))}`,
-            changeUserAttributes: `/change-user-attributes/${serviceId}/${selfServiceClientId}/${authClientId}?userAttributes=${encodeURI(arraysToString(client.scopes))}`,
+            changeRedirectUris: `/change-redirect-URIs/${serviceId}/${selfServiceClientId}/${authClientId}?redirectUris=${encodeURI(client.redirect_uris.join(" "))}`,
+            changeUserAttributes: `/change-user-attributes/${serviceId}/${selfServiceClientId}/${authClientId}?userAttributes=${encodeURI(client.scopes.join(" "))}`,
             changePublicKey: `/change-public-key/${serviceId}/${selfServiceClientId}/${authClientId}?publicKey=${encodeURI(client.clientId)}`,
-            changePostLogoutUris: `/change-post-logout-URIs/${serviceId}/${selfServiceClientId}/${authClientId}?redirectUris=${encodeURI(arraysToString(client.post_logout_redirect_uris))}`,
+            changePostLogoutUris: `/change-post-logout-URIs/${serviceId}/${selfServiceClientId}/${authClientId}?redirectUris=${encodeURI(client.post_logout_redirect_uris.join(" "))}`,
         }
     });
     req.session.updatedField = undefined;
 });
-
-function arraysToString(array: string[]): string {
-    return array.reduce((output, value) => { return output === "" ? output + value : output + " " + value })
-}
 
 const DEFAULT_PUBLIC_KEY = 'MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAp2mLkQGo24Kz1rut0oZlviMkGomlQCH+iT1pFvegZFXq39NPjRWyatmXp/XIUPqCq9Kk8/+tq4Sgjw+EM5tATJ06j5r+35of58ATGVPniW//IhGizrv6/ebGcGEUJ0Y/ZmlCHYPV+lbewpttQ/IYKM1nr3k/Rl6qepbVYe+MpGubluQvdhgUYel9OzxiOvUk7XI0axPquiXzoEgmNNOai8+WhYTkBqE3/OucAv+XwXdnx4XHmKzMwTv93dYMpUmvTxWcSeEJ/4/SrbiK4PyHWVKU2BozfSUejVNhahAzZeyyDwhYJmhBaZi/3eOOlqGXj9UdkOXbl3vcwBH8wD30O9/4F5ERLKxzOaMnKZ+RpnygWF0qFhf+UeFMy+O06sdgiaFnXaSCsIy/SohspkKiLjNnhvrDNmPLMQbQKQlJdcp6zUzI7Gzys7luEmOxyMpA32lDBQcjL7KNwM15s4ytfrJ46XEPZUXESce2gj6NazcPPsrTa/Q2+oLS9GWupGh7AgMBAAE=';
 

--- a/express/src/views/dashboard/change-user-attributes.njk
+++ b/express/src/views/dashboard/change-user-attributes.njk
@@ -54,20 +54,20 @@
               {
                 value: "email",
                 text: "Email address",
-                checked: true
+                checked: email
               },
               {
                 value: "phone",
                 text: "Phone number",
-                checked: true
+                checked: phone
               },
               {
-                value: "offlineAccess",
+                value: "offline_access",
                 text: "Offline access",
                 hint: {
                   html: "This gives you a refresh token so you can access the <code>/userinfo</code> endpoint for longer than 3 minutes"
                 },
-                checked: false
+                checked: offline_access
               }
             ]
           }) }}


### PR DESCRIPTION
Quick solution to save user attributes.  Has messy logic to deal with the delivery of ticked checkboxes and ensure openid is always an option.  We could / should consider displaying nicer versions of the attributes - currently we use the actual attribute names expcted by Auth.  This makes the logic simpler right now but looks a bit odd.

Alter offlineAccess to offline_access in template and route/controllers as that's the parameter the auth API expects.
Add code to call Auth API and update client configuration.
Switch to using join instead of an array.reduce operation.  Barely relevant to this story but I saw we should probably render attributes with a comma-space so made the change everywhere.