### PR TITLE
DFA-916 Update post logout URIs

### DIFF
--- a/express/src/middleware/urisValidator.ts
+++ b/express/src/middleware/urisValidator.ts
@@ -1,0 +1,71 @@
+import {NextFunction, Request, Response} from "express";
+
+type MiddlewareFunction<T, U, V> = (T: Request, U: Response, V: NextFunction) => void;
+
+export function urisValidator(template: string, whichUris: string): MiddlewareFunction<Request, Response, NextFunction> {
+    return async (req: Request, res: Response, next: NextFunction) => {
+        let stringOfUris = req.body[whichUris];
+        if (stringOfUris === "") {
+            const errorMessages = new Map<string, string>();
+            errorMessages.set(whichUris, 'Enter your redirect URIs');
+            res.render(template, {
+                errorMessages: errorMessages,
+                value: req.body[whichUris],
+                serviceId: req.params.serviceId,
+                selfServiceClientId: req.params.selfServiceClientId,
+                clientId: req.params.clientId
+            });
+            return;
+        }
+        const urlStrings = stringOfUris.split(" ").filter((url: string) => url !== "");
+        const invalidUris: string[] = [];
+
+        for (const url of urlStrings) {
+            try {
+                new URL(url);
+            } catch ( error ) {
+                invalidUris.push(url);
+            }
+        }
+
+        if(invalidUris.length > 0) {
+            const errorMessages = new Map<string, string>();
+            if(invalidUris.length == 1) {
+                errorMessages.set(whichUris, `${invalidUris[0]} is not a valid URL`);
+            } else {
+                errorMessages.set(whichUris, `The following URLs are not valid: ${invalidUris.join(" ")}`);
+            }
+            res.render(template, {
+                errorMessages: errorMessages,
+                value: req.body[whichUris],
+                serviceId: req.params.serviceId,
+                selfServiceClientId: req.params.selfServiceClientId,
+                clientId: req.params.clientId
+            });
+            return;
+        }
+
+        for (const url of urlStrings) {
+            const errorMessages = new Map<string, string>();
+            errorMessages.set(whichUris, "URLs must be https (except for localhost)");
+            let newUrl = new URL(url);
+            console.log(newUrl)
+            if( !isValidLocalHost(newUrl) && newUrl.protocol !== "https:" ) {
+                res.render(template, {
+                    errorMessages: errorMessages,
+                    value: req.body[whichUris],
+                    serviceId: req.params.serviceId,
+                    selfServiceClientId: req.params.selfServiceClientId,
+                    clientId: req.params.clientId
+                });
+                return;
+            }
+        }
+
+        next();
+    }
+}
+
+function isValidLocalHost(url: URL): boolean {
+    return url.hostname === "localhost" && (url.protocol === "http:" || url.protocol === "https:");
+}

--- a/express/src/routes/manage-account.ts
+++ b/express/src/routes/manage-account.ts
@@ -29,7 +29,7 @@ router.get('/client-details/:serviceId', async (req, res) => {
         clientId: client.clientId,
         redirectUrls: arraysToString(client.redirect_uris),
         userAttributesRequired: arraysToString(client.scopes),
-        userPublicKey: client.public_key,
+        userPublicKey: client.public_key == DEFAULT_PUBLIC_KEY ? "" : client.public_key,
         postLogoutRedirectUrls: arraysToString(client.post_logout_redirect_uris),
         urls: {
             changeClientName: `/change-client-name/${serviceId}/${selfServiceClientId}/${authClientId}?clientName=${encodeURI(client.data)}`,
@@ -46,5 +46,6 @@ function arraysToString(array: string[]): string {
     return array.reduce((output, value) => { return output === "" ? output + value : output + " " + value })
 }
 
+const DEFAULT_PUBLIC_KEY = 'MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAp2mLkQGo24Kz1rut0oZlviMkGomlQCH+iT1pFvegZFXq39NPjRWyatmXp/XIUPqCq9Kk8/+tq4Sgjw+EM5tATJ06j5r+35of58ATGVPniW//IhGizrv6/ebGcGEUJ0Y/ZmlCHYPV+lbewpttQ/IYKM1nr3k/Rl6qepbVYe+MpGubluQvdhgUYel9OzxiOvUk7XI0axPquiXzoEgmNNOai8+WhYTkBqE3/OucAv+XwXdnx4XHmKzMwTv93dYMpUmvTxWcSeEJ/4/SrbiK4PyHWVKU2BozfSUejVNhahAzZeyyDwhYJmhBaZi/3eOOlqGXj9UdkOXbl3vcwBH8wD30O9/4F5ERLKxzOaMnKZ+RpnygWF0qFhf+UeFMy+O06sdgiaFnXaSCsIy/SohspkKiLjNnhvrDNmPLMQbQKQlJdcp6zUzI7Gzys7luEmOxyMpA32lDBQcjL7KNwM15s4ytfrJ46XEPZUXESce2gj6NazcPPsrTa/Q2+oLS9GWupGh7AgMBAAE=';
 
 export default router;


### PR DESCRIPTION
Allow updating of post logout URIs.

Write middleware component that can be used for each redirect-uri configuration value. This contains some truly awful logic but I'm not willing to sit here until 11pm coming up with something nice when we have something that works.

Use middleware for post-logout redirect uris and the normal urs.

Update details using lambda-facade