### PR TITLE
BAU Public Key update

### DIFF
--- a/express/src/lib/publicKeyUtils/public-key-utils.ts
+++ b/express/src/lib/publicKeyUtils/public-key-utils.ts
@@ -1,0 +1,32 @@
+import {createPublicKey} from 'crypto';
+
+const BEGIN = "-----BEGIN PUBLIC KEY-----";
+const END = "-----END PUBLIC KEY-----";
+export default function getAuthApiCompliantPublicKey(publicKey: string): string {
+    // assume PEM with headers
+    try {
+        createPublicKey({key: publicKey, format: 'pem'});
+        return publicKey
+            .replace(BEGIN, "")
+            .replace(END, "")
+            .replace("\n", "")
+            .replace("\r", "");
+    } catch (err) {
+        console.log(`Failed to convert\n${publicKey}`)
+    }
+
+    let publicKeyWithHeaders = `${BEGIN}\n${publicKey}\n${END}\n`
+    try {
+        createPublicKey({key: publicKeyWithHeaders, format: 'pem'});
+        return publicKeyWithHeaders
+            .replace(BEGIN, "")
+            .replace(END, "")
+            .replace("\n", "")
+            .replace("\r", "");
+    } catch (err) {
+        console.log(`Failed to convert\n${publicKeyWithHeaders}`)
+    }
+
+    throw new Error(`Failed to convert\n${publicKeyWithHeaders}\n`)
+
+}

--- a/express/src/middleware/convertPublicKeyForAuth.ts
+++ b/express/src/middleware/convertPublicKeyForAuth.ts
@@ -1,0 +1,20 @@
+import {NextFunction, Request, Response} from "express";
+import getAuthApiCompliantPublicKey from "../lib/publicKeyUtils/public-key-utils";
+
+export function convertPublicKeyForAuth(req: Request, res: Response, next: NextFunction) {
+
+    try {
+        req.body.authCompliantPublicKey =  getAuthApiCompliantPublicKey(req.body.serviceUserPublicKey as string);
+    } catch (err) {
+        console.log(err)
+        const errorMessages = new Map<string, string>();
+        errorMessages.set('serviceUserPublicKey', 'Enter a valid public key');
+        res.render('dashboard/change-public-key.njk', {
+            errorMessages: errorMessages, serviceId: req.params.serviceId,
+            selfServiceClientId: req.params.selfServiceClientId,
+            clientId: req.params.clientId
+        });
+        return;
+    }
+    next();
+}

--- a/express/src/routes/testing-routes.ts
+++ b/express/src/routes/testing-routes.ts
@@ -82,10 +82,10 @@ router.post('/change-user-attributes/:serviceId/:selfServiceClientId/:clientId',
     const facade: LambdaFacadeInterface = req.app.get("lambdaFacade");
     const attributes: string[] = ["openid"];
 
-    if(Array.isArray(req.body.userAttributes)) {
-        attributes.push( ...req.body.userAttributes );
-    } else if( typeof req.body.userAttributes === "string" ) {
-        attributes.push( req.body.userAttributes );
+    if (Array.isArray(req.body.userAttributes)) {
+        attributes.push(...req.body.userAttributes);
+    } else if (typeof req.body.userAttributes === "string") {
+        attributes.push(req.body.userAttributes);
     }
 
     console.log(attributes)
@@ -139,14 +139,22 @@ router.post('/change-public-key/:serviceId/:selfServiceClientId/:clientId', asyn
     if (publicKey === "") {
         const errorMessages = new Map<string, string>();
         errorMessages.set('serviceUserPublicKey', 'Paste in a public key');
-        res.render('dashboard/change-public-key.njk', {errorMessages: errorMessages, clientId: req.params.clientId});
+        res.render('dashboard/change-public-key.njk', {
+            errorMessages: errorMessages, serviceId: req.params.serviceId,
+            selfServiceClientId: req.params.selfServiceClientId,
+            clientId: req.params.clientId
+        });
         return;
     }
 
     if (!publicKey.startsWith("-----BEGIN PUBLIC KEY-----") || !publicKey.endsWith("-----END PUBLIC KEY-----")) {
         const errorMessages = new Map<string, string>();
         errorMessages.set('serviceUserPublicKey', 'Enter a valid public key in PEM format, including the headers');
-        res.render('dashboard/change-public-key.njk', {errorMessages: errorMessages, clientId: req.params.clientId});
+        res.render('dashboard/change-public-key.njk', {
+            errorMessages: errorMessages, serviceId: req.params.serviceId,
+            selfServiceClientId: req.params.selfServiceClientId,
+            clientId: req.params.clientId
+        });
         return;
     }
 
@@ -157,7 +165,7 @@ router.post('/change-public-key/:serviceId/:selfServiceClientId/:clientId', asyn
 
     const facade: LambdaFacadeInterface = req.app.get("lambdaFacade");
     try {
-       await facade.updateClient(req.params.serviceId, req.params.selfServiceClientId, req.params.clientId, {public_key: publicKey}, req.session.authenticationResult?.AccessToken as string);
+        await facade.updateClient(req.params.serviceId, req.params.selfServiceClientId, req.params.clientId, {public_key: publicKey}, req.session.authenticationResult?.AccessToken as string);
     } catch (error) {
         console.log(error)
         res.redirect('/there-is-a-problem');


### PR DESCRIPTION
Fix bug in update private key page where path parameters weren't passed on so subsequent clicks on 'change' failed.

Shift some of the public key validation into middleware that's slightly more tolerant of what's pasted in (headers or no headers) and fails if the data can't be converted into a public key object by node.