### PR TITLE
DFA-2024 Make logged in status available to views

### DIFF
--- a/express/src/app.ts
+++ b/express/src/app.ts
@@ -9,6 +9,7 @@ import manageAccount from "./routes/manage-account";
 
 import testingRoutes from "./routes/testing-routes";
 import {User} from "../@types/User";
+import {setSignedInStatus} from "./middleware/setSignedInStatus/setSignedInStatus";
 
 const app = express();
 import(`./lib/cognito/${process.env.COGNITO_CLIENT||"CognitoClient"}`).then(
@@ -47,10 +48,13 @@ declare module 'express-session' {
         cognitoUser: AdminGetUserCommandOutput;
         selfServiceUser: User;
         updatedField: string;
+        isSignedIn: boolean;
     }
 }
 
 configureViews(app);
+
+app.use(setSignedInStatus);
 
 app.use("/", createAccount);
 app.use("/", signIn);

--- a/express/src/controllers/sign-in.ts
+++ b/express/src/controllers/sign-in.ts
@@ -26,7 +26,12 @@ export const showLoginOtpMobile = async function(req: Request, res: Response) {
 
 export const processLoginOtpMobile = async function(req: Request, res: Response) {
     // TO DO add the functionality to process the login mobile otp
-    res.redirect('/account/list-services');
+    if (true) { // because OTP was correct and we've implemented that
+        req.session.isSignedIn = true;
+        res.redirect('/account/list-services');
+    } else {
+        res.redirect('/sign-in-otp-mobile');
+    }
 }
 
 export const processEmailAddress = async function (req: Request, res: Response) {
@@ -80,4 +85,8 @@ export const processSignInForm = async function(req: Request, res: Response) {
     res.redirect('/sign-in-otp-mobile');
     return;
 
+}
+
+export const signOut = async function(req: Request, res: Response) {
+    req.session.destroy(() => res.redirect('/'));
 }

--- a/express/src/middleware/setSignedInStatus/setSignedInStatus.ts
+++ b/express/src/middleware/setSignedInStatus/setSignedInStatus.ts
@@ -1,0 +1,6 @@
+import express, {Request, Response, NextFunction} from "express";
+
+export function setSignedInStatus(req: Request, res: Response, next: NextFunction) {
+    res.locals.isSignedIn = req.session.isSignedIn !== undefined && req.session.isSignedIn
+    next();
+}

--- a/express/src/routes/sign-in.ts
+++ b/express/src/routes/sign-in.ts
@@ -5,7 +5,8 @@ import {
     showSignInFormEmail,
     showSignInFormPassword,
     showLoginOtpMobile,
-    processLoginOtpMobile
+    processLoginOtpMobile,
+    signOut
 } from "../controllers/sign-in";
 import {emailValidator} from "../middleware/emailValidator";
 import {passwordValidator} from "../middleware/passwordValidator";
@@ -19,5 +20,7 @@ router.get('/sign-in-password', showSignInFormPassword);
 router.post('/sign-in-password', passwordValidator('sign-in-password.njk', true), processSignInForm);
 router.get('/sign-in-otp-mobile', showLoginOtpMobile);
 router.post('/sign-in-otp-mobile', mobileOtpValidator('sign-in-otp-mobile.njk', true), processLoginOtpMobile);
+
+router.get('/account/sign-out', signOut);
 
 export default router;

--- a/express/src/views/layout-dashboard.njk
+++ b/express/src/views/layout-dashboard.njk
@@ -120,8 +120,8 @@
                 Your account
               </a>
             </li>
-            <li class="govuk-header__navigation-item{% if active=='sign-out' %} govuk-header__navigation-item--active{% endif %}">
-              <a class="govuk-header__link" href="/email-address">
+            <li class="govuk-header__navigation-item">
+              <a class="govuk-header__link" href="/account/sign-out">
                 Sign out
               </a>
             </li>


### PR DESCRIPTION
Menus will change based on whether a user is logged in or not.  Take this status from the session and make it available to request-response cycles with a default middleware.

Stub in logic for OTP processing - this is the point at which we determine whether a user has logged in successfully. set `req.session.isSignedIn` to true until OTP code is implemented.
Create `setSignedInStatus.ts` middleware.  Set `res.locals.isSignedIn` to true if session exists and `req.session.isSignedIn` is true, otherwise set value to false.
Add a sign-out function to the sign-in controller `¯\_(ツ)_/¯`
Use above controller in sign-in routes - `/account/sign-out`
Point the sign-out link in the layout-dashboard.njk to the sign-out route.
Insert default middleware into middleware chain in app.ts.  Add isSignedIn to session definition in app.ts