### PR TITLE
DFA-2030: Apply formatting to the acceptance tests

### DIFF
--- a/express/features/email-verification-resend.feature
+++ b/express/features/email-verification-resend.feature
@@ -1,22 +1,23 @@
 Feature: A contact form to resend the verification code to mobile
+
   Background:
     Given that the user is on the `Check your email` page
 
   Scenario: User doesn’t receive their code
-    When they click on the "Not received an email?" link 
+    When they click on the "Not received an email?" link
     Then they should be directed to the following page: "/create/resend-email-code"
-  
+
   Scenario: The user wants to contact the service via slack
-    When they click on the "Not received an email?" link 
-    And they click on the "Slack channel" link 
+    When they click on the "Not received an email?" link
+    And they click on the "Slack channel" link
     Then they should be directed to the following URL: "https://ukgovernmentdigital.slack.com/?redir=%2Farchives%2FC02AQUJ6WTC"
 
   Scenario: The user wants to contact the service
-    When they click on the "Not received an email?" link 
-    And they click on the "support form" link 
+    When they click on the "Not received an email?" link
+    And they click on the "support form" link
     Then they should be directed to the following URL: "https://www.sign-in.service.gov.uk/support"
 
   Scenario: The user wants the app to resend their code
-    When they click on the "Not received an email?" link 
+    When they click on the "Not received an email?" link
     And they select the Submit button
     Then they should be directed to the following page: "/create/check-email"

--- a/express/features/mobile-verification-resend.feature
+++ b/express/features/mobile-verification-resend.feature
@@ -1,22 +1,23 @@
 Feature: A contact form to resend the verification code to mobile
+
   Background:
     Given that the user is on the `Check your phone` page
 
   Scenario: User does not receive their code
-    When they click on the "Not received a text message?" link 
+    When they click on the "Not received a text message?" link
     Then they should be directed to the following page: "/create/resend-phone-code"
 
   Scenario: The user wants to contact the service via slack
-    When they click on the "Not received a text message?" link 
-    And they click on the "Slack channel" link 
+    When they click on the "Not received a text message?" link
+    And they click on the "Slack channel" link
     Then they should be directed to the following URL: "https://ukgovernmentdigital.slack.com/?redir=%2Farchives%2FC02AQUJ6WTC"
 
   Scenario: The user wants to contact the service
-    When they click on the "Not received a text message?" link 
-    And they click on the "support form" link 
+    When they click on the "Not received a text message?" link
+    And they click on the "support form" link
     Then they should be directed to the following URL: "https://www.sign-in.service.gov.uk/support"
 
   Scenario: The user wants the app to resend their code
-    When they click on the "Not received a text message?" link 
+    When they click on the "Not received a text message?" link
     And they select the Submit button
     Then they should be directed to the following page: "/create/resend-phone-code"

--- a/express/features/support/steps/email-verification-resend-steps.ts
+++ b/express/features/support/steps/email-verification-resend-steps.ts
@@ -1,12 +1,9 @@
-
-   
-import {Given} from "@cucumber/cucumber";
+import { Given } from '@cucumber/cucumber';
 
 Given('that the user is on the `Check your email` page', async function () {
-  await this.goToPath('/create/get-email');
-  await this.page.type("#emailAddress", 'registering-successfully@gds.gov.uk');
-  await this.page.waitForSelector('#submit');
-  await this.page.click('#submit');
-  await this.page.waitForSelector('#resend-code-page');       
+    await this.goToPath('/create/get-email');
+    await this.page.type('#emailAddress', 'registering-successfully@gds.gov.uk');
+    await this.page.waitForSelector('#submit');
+    await this.page.click('#submit');
+    await this.page.waitForSelector('#resend-code-page');
 });
-

--- a/express/features/support/steps/mobile-verification-resend-steps.ts
+++ b/express/features/support/steps/mobile-verification-resend-steps.ts
@@ -1,24 +1,21 @@
-
-   
-import {Given} from "@cucumber/cucumber";
+import { Given } from '@cucumber/cucumber';
 
 Given('that the user is on the `Check your phone` page', async function () {
-  await this.goToPath('/create/get-email');
-  await this.page.type("#emailAddress", 'registering-successfully@gds.gov.uk');
-  await this.page.waitForSelector('#submit');
-  await this.page.click('#submit');
-  await this.page.waitForSelector('#create-email-otp');
-  await this.page.waitForTimeout(1000)
-  await this.page.type("#create-email-otp", '435553');
-  await this.page.click('#submit')
-  await this.page.waitForSelector('#password');    
-  await this.page.waitForTimeout(1000)
-  await this.page.type("#password", 'strongPassword');
-  await this.page.click('#submit');
-  await this.page.waitForSelector('#mobileNumber');
-  await this.page.waitForTimeout(1000)
-  await this.page.type("#mobileNumber", '+447998708769');
-  await this.page.click('#submit');
-  await this.page.waitForTimeout(1000)
+    await this.goToPath('/create/get-email');
+    await this.page.type('#emailAddress', 'registering-successfully@gds.gov.uk');
+    await this.page.waitForSelector('#submit');
+    await this.page.click('#submit');
+    await this.page.waitForSelector('#create-email-otp');
+    await this.page.waitForTimeout(1000)
+    await this.page.type('#create-email-otp', '435553');
+    await this.page.click('#submit')
+    await this.page.waitForSelector('#password');
+    await this.page.waitForTimeout(1000)
+    await this.page.type('#password', 'strongPassword');
+    await this.page.click('#submit');
+    await this.page.waitForSelector('#mobileNumber');
+    await this.page.waitForTimeout(1000)
+    await this.page.type('#mobileNumber', '+447998708769');
+    await this.page.click('#submit');
+    await this.page.waitForTimeout(1000)
 });
-

--- a/express/features/support/steps/shared-functions.ts
+++ b/express/features/support/steps/shared-functions.ts
@@ -1,5 +1,5 @@
-import {ElementHandle, Page} from "puppeteer";
-import {strict as assert} from "assert";
+import { strict as assert } from 'assert';
+import { ElementHandle, Page } from 'puppeteer';
 
 export async function getLink(page: Page, linkText: string): Promise<any> {
     let links = await page.$x(`//a[contains(., '${linkText}')]`);

--- a/express/features/support/steps/shared-steps.ts
+++ b/express/features/support/steps/shared-steps.ts
@@ -1,6 +1,7 @@
-import {Given, When, Then} from "@cucumber/cucumber";
-import {strict as assert} from "assert";
-import {getLink, checkUrl} from './shared-functions';
+import { Given, Then, When } from '@cucumber/cucumber';
+import { strict as assert } from 'assert';
+import { Page } from "puppeteer";
+import { checkUrl, getLink } from './shared-functions';
 
 Given('that the user is on the {string} page', async function (route: string) {
     await this.goToPath(route);
@@ -9,7 +10,7 @@ Given('that the user is on the {string} page', async function (route: string) {
 When('they click on the {string} link', async function (text: string) {
     let links = await this.page.$x(`//a[contains(., '${text}')]`);
     await Promise.all([
-        this.page.waitForNavigation({timeout: 10000}),
+        this.page.waitForNavigation({ timeout: 10000 }),
         links[0].click()
     ]);
 });
@@ -17,7 +18,7 @@ When('they click on the {string} link', async function (text: string) {
 When('they click on the {string} button-link', async function (text: string) {
     let links = await this.page.$x(`//a[contains(., '${text}') and contains(concat(" ", normalize-space(@class), " "), " govuk-button ")]`);
     await Promise.all([
-        this.page.waitForNavigation({timeout: 10000}),
+        this.page.waitForNavigation({ timeout: 10000 }),
         links[0].click()
     ]);
 });
@@ -25,7 +26,7 @@ When('they click on the {string} button-link', async function (text: string) {
 When('they select the Submit button', async function () {
     await Promise.all([
         this.page.waitForNavigation(),
-        this.page.click("#submit")
+        this.page.click('#submit')
     ]);
 });
 
@@ -49,17 +50,17 @@ Then('their data is saved in the spreadsheet', async function () {
 
 Then('the error message {string} must be displayed for the {string} field', async function (errorMessage, field) {
     const errorLink = await this.page.$x(`//div[contains(concat(" ", normalize-space(@class), " "), " govuk-error-summary ")]//a[@href="#${field}"]`);
-    await checkErrorMessageDisplayedAboveElement(this.page, errorLink, errorMessage, field);
+    await checkErrorMessageDisplayedForField(this.page, errorLink, errorMessage, field);
 });
 
 Then('the error message {string} must be displayed for the {string} radios', async function (errorMessage, field) {
     const errorLink = await this.page.$x(`//div[contains(concat(" ", normalize-space(@class), " "), " govuk-error-summary ")]//a[@href="#${field}-error"]`);
-    await checkErrorMessageDisplayedAboveElement(this.page, errorLink, errorMessage, field);
+    await checkErrorMessageDisplayedForField(this.page, errorLink, errorMessage, field);
 });
 
 Then('they should see the text {string}', async function (text) {
     let bodyText: string = await this.page.$eval('body', (element: any) => element.textContent)
-    assert.equal(bodyText.includes(text), true, `Body text does not contain "${text}"`)
+    assert.equal(bodyText.includes(text), true, `Body text does not contain '${text}'`)
 });
 
 Then('the {string} link will point to the following URL: {string}', async function (linkText, expectedUrl) {
@@ -72,15 +73,15 @@ Then('the {string} link will point to the following page: {string}', async funct
     await checkUrl(this.page, link, expectedPage);
 });
 
-async function checkErrorMessageDisplayedAboveElement(page: Page, errorLink: any, errorMessage: string, field: string) {
+async function checkErrorMessageDisplayedForField(page: Page, errorLink: any, errorMessage: string, field: string) {
     assert.notEqual(errorLink.length, 0, `Expected to find the message ${errorMessage} in the error summary.`);
 
-    const actualMessageInSummary = await page.evaluate((el: { textContent: any; }) => el.textContent, errorLink[0]);
-    assert.equal(actualMessageInSummary, errorMessage, `Expected text of the link to be ${errorMessage}`);
+    const messageInSummary = await page.evaluate((el: { textContent: any; }) => el.textContent, errorLink[0]);
+    assert.equal(messageInSummary, errorMessage, `Expected text of the link to be ${errorMessage}`);
 
-    const messageAboveElement = await page.$x(`//span[contains(concat(" ", normalize-space(@class), " "), " govuk-error-message ") and @id="${field}-error" ]`);
-    assert.notEqual(messageAboveElement.length, 0, `Expected to find the message ${errorMessage} above the ${field} field.`);
+    const messagesAboveElement = await page.$x(`//span[contains(concat(" ", normalize-space(@class), " "), " govuk-error-message ") and @id="${field}-error" ]`);
+    assert.notEqual(messagesAboveElement.length, 0, `Expected to find the message ${errorMessage} above the ${field} field.`);
 
-    const actualMessageAboveSummary = await page.evaluate((el: { textContent: any; }) => el.textContent, messageAboveElement[0]);
-    assert.equal(actualMessageAboveSummary.trim(), "Error: " + errorMessage, `Expected the message above the ${field} field to be ${errorMessage}`);
+    const messageAboveElement = await page.evaluate((el: { textContent: any; }) => el.textContent, messagesAboveElement[0]);
+    assert.equal(messageAboveElement.trim(), "Error: " + errorMessage, `Expected the message above the ${field} field to be ${errorMessage}`);
 }

--- a/express/features/support/steps/sign-in-steps.ts
+++ b/express/features/support/steps/sign-in-steps.ts
@@ -1,14 +1,14 @@
-import {When} from "@cucumber/cucumber";
+import { When } from "@cucumber/cucumber";
 
 When('the user registers the email {string}', async function (email: string) {
     let emailInput = await this.page.$('#emailAddress');
-    await emailInput.click({clickCount: 3});
+    await emailInput.click({ clickCount: 3 });
     await emailInput.press('Backspace');
     await this.page.type("#emailAddress", email);
     await Promise.all(
         [
-            this.page.waitForNavigation({timeout: 10000}),
+            this.page.waitForNavigation({ timeout: 10000 }),
             this.page.click('#submit')
         ]
     )
-})
+});

--- a/express/features/support/test-setup.ts
+++ b/express/features/support/test-setup.ts
@@ -1,9 +1,9 @@
-import {Browser} from "puppeteer";
-import {After, AfterAll, Before, BeforeAll} from "@cucumber/cucumber";
-import {IWorldOptions} from "@cucumber/cucumber/lib/support_code_library_builder/world";
+import { After, AfterAll, Before, BeforeAll } from "@cucumber/cucumber";
+import { IWorldOptions } from "@cucumber/cucumber/lib/support_code_library_builder/world";
+import { Browser } from "puppeteer";
 
 const puppeteer = require('puppeteer');
-const {setWorldConstructor, World} = require("@cucumber/cucumber");
+const { setWorldConstructor, World } = require("@cucumber/cucumber");
 
 let browser: Browser;
 
@@ -19,7 +19,7 @@ class TestContext extends World {
 
 BeforeAll(async function () {
     console.log(`Running tests against ${process.env.HOST || "local"}`)
-    browser = await puppeteer.launch({headless: true});
+    browser = await puppeteer.launch({ headless: true });
 })
 
 Before(async function () {


### PR DESCRIPTION
- Correctly construct URLs in feature tests 

Avoid failing tests due to double slashes caused by directly adding two strings. Use the URL class instead to handle URL construction.

---

- Remove duplicated code fragments by moving the repeated blocks into functions.
- Apply formatting
- Optimise imports
- Use one kind of quotes for strings (single quotes)