### PR TITLE
BAU: Upgrade to the latest GOV.UK Design System

### DIFF
--- a/express/assets/css/app.scss
+++ b/express/assets/css/app.scss
@@ -46,12 +46,6 @@ div.feature-panel {
   }
 }
 
-// scss-lint:disable IdSelector
-#main-content {
-  display: block;
-  margin-bottom: govuk-spacing(9);
-}
-
 // scss-lint:enable IdSelector
 .hero-alternative-action {
   @include govuk-font($size: 19);

--- a/express/assets/css/modules/_side-navigation.scss
+++ b/express/assets/css/modules/_side-navigation.scss
@@ -1,6 +1,4 @@
 .side-navigation {
-  margin-bottom: govuk-spacing(6);
-
   ol,
   ul {
     list-style: none;

--- a/express/features/support/steps/shared-functions.ts
+++ b/express/features/support/steps/shared-functions.ts
@@ -4,19 +4,17 @@ import {ElementHandle, Page} from "puppeteer";
 const DEFAULT_TIMEOUT = 5000;
 
 export async function getLink(page: Page, linkText: string): Promise<ElementHandle> {
-    const links = await page.$x(`//a[contains(normalize-space(.), '${linkText}')]`);
+    const links = await page.$x(`//a[contains(text(), "${linkText}")]`);
     return getSingleLink(links, linkText);
 }
 
 export async function getLinkWithHref(page: Page, href: string): Promise<ElementHandle> {
-    const links = await page.$x(`//a[contains(@href, '${href}')]`);
+    const links = await page.$x(`//a[contains(@href, "${href}")]`);
     return getSingleLink(links, href);
 }
 
-export async function getButtonLink(page: Page, linkText: string): Promise<any> {
-    const links = await page.$x(
-        `//a[contains(., '${linkText}') and contains(concat(" ", normalize-space(@class), " "), " govuk-button ")]`
-    );
+export async function getButtonLink(page: Page, linkText: string): Promise<ElementHandle> {
+    const links = await page.$x(`//a[contains(text(), "${linkText}")][@class="govuk-button"]`);
     return getSingleLink(links, linkText);
 }
 

--- a/express/features/support/steps/shared-steps.ts
+++ b/express/features/support/steps/shared-steps.ts
@@ -58,16 +58,12 @@ Then("their data is saved in the spreadsheet", async function () {
 });
 
 Then("the error message {string} must be displayed for the {string} field", async function (errorMessage, field) {
-    const errorLink = await this.page.$x(
-        `//div[contains(concat(" ", normalize-space(@class), " "), " govuk-error-summary ")]//a[@href="#${field}"]`
-    );
+    const errorLink = await this.page.$x(`//div[@class="govuk-error-summary"]//a[@href="#${field}"]`);
     await checkErrorMessageDisplayedForField(this.page, errorLink, errorMessage, field);
 });
 
 Then("the error message {string} must be displayed for the {string} radios", async function (errorMessage, field) {
-    const errorLink = await this.page.$x(
-        `//div[contains(concat(" ", normalize-space(@class), " "), " govuk-error-summary ")]//a[@href="#${field}-error"]`
-    );
+    const errorLink = await this.page.$x(`//div[@class="govuk-error-summary"]//a[@href="#${field}-error"]`);
     await checkErrorMessageDisplayedForField(this.page, errorLink, errorMessage, field);
 });
 
@@ -92,9 +88,7 @@ async function checkErrorMessageDisplayedForField(page: Page, errorLink: any, er
     const messageInSummary = await page.evaluate((el: {textContent: any}) => el.textContent, errorLink[0]);
     assert.equal(messageInSummary, errorMessage, `Expected text of the link to be ${errorMessage}`);
 
-    const messagesAboveElement = await page.$x(
-        `//span[contains(concat(" ", normalize-space(@class), " "), " govuk-error-message ") and @id="${field}-error" ]`
-    );
+    const messagesAboveElement = await page.$x(`//p[@class="govuk-error-message"][@id="${field}-error"]`);
     assert.notEqual(messagesAboveElement.length, 0, `Expected to find the message ${errorMessage} above the ${field} field.`);
 
     const messageAboveElement = await page.evaluate((el: {textContent: any}) => el.textContent, messagesAboveElement[0]);

--- a/express/package.json
+++ b/express/package.json
@@ -26,7 +26,7 @@
     "express-async-errors": "^3.1.1",
     "node-sass-package-importer": "^5.3.2",
     "rfc822-validate": "^1.0.0",
-    "govuk-frontend": "^3.13.1",
+    "govuk-frontend": "^4.3.1",
     "cookie-parser": "^1.4.6",
     "nodemon": "^2.0.19",
     "nunjucks": "^3.2.3",

--- a/express/src/app.ts
+++ b/express/src/app.ts
@@ -5,7 +5,7 @@ import "express-async-errors";
 import sessions from "express-session";
 import path from "path";
 import {User} from "../@types/user";
-import configureViews from "./lib/configureViews";
+import configureViews from "./config/configure-views";
 import {RedirectError, RenderError} from "./lib/errors";
 import setSignedInStatus from "./middleware/setSignedInStatus";
 import createAccount from "./routes/create-account-or-sign-in";

--- a/express/src/config/configure-views.ts
+++ b/express/src/config/configure-views.ts
@@ -1,9 +1,14 @@
 import {Express} from "express-serve-static-core";
 import {configure, render} from "nunjucks";
-import path from "path";
 
 export default function (app: Express, viewPath = "../../src/views") {
-    configure([viewPath, path.dirname(require.resolve("govuk-frontend/package.json"))], {
+    const govukViews = require.resolve("govuk-frontend").match(/.*govuk-frontend\//)?.[0];
+
+    if (!govukViews) {
+        throw "Couldn't load govuk-frontend module";
+    }
+
+    configure([viewPath, govukViews], {
         autoescape: true,
         noCache: true,
         express: app

--- a/express/src/views/account/account.njk
+++ b/express/src/views/account/account.njk
@@ -8,17 +8,11 @@
 
 {% block mainContent %}
   {% if updatedField %}
-    {% set htmlNotificationBanner %}
+    {% call govukNotificationBanner({type: "success"}) %}
       <h3 class="govuk-notification-banner__heading">
         You have changed your {{ updatedField }}
       </h3>
-    {% endset %}
-
-    {{ govukNotificationBanner({
-      classes: 'govuk-!-margin-bottom-5 govuk-!-margin-top-3',
-      html: htmlNotificationBanner,
-      type: 'success'
-    }) }}
+    {% endcall %}
   {% endif %}
 
   <h1 class="govuk-heading-l">Your account</h1>

--- a/express/src/views/account/change-phone-number.njk
+++ b/express/src/views/account/change-phone-number.njk
@@ -30,6 +30,7 @@
         text:  errorMessages.mobileNumber
       } if  errorMessages
     }) }}
+
     <div class="govuk-button-group">
       {{ govukButton({ text: "Confirm", attributes: {id: "continue"} }) }}
       <a class="govuk-link" href="/account">Cancel</a>

--- a/express/src/views/account/check-email.njk
+++ b/express/src/views/account/check-email.njk
@@ -43,9 +43,7 @@
       } if errorMessages else false
     }) }}
 
-    <button id="submit" type="submit" class="govuk-button" data-module="govuk-button" formnovalidate>
-      Continue
-    </button>
+    {{ govukButton({ text: "Continue", attributes: {id: "submit"} }) }}
 
     <p class="govuk-body">
       <a id="resend-code-page" class="govuk-link" href="/create/resend-email-code">Not received an email?</a>

--- a/express/src/views/common/cookie-banner.njk
+++ b/express/src/views/common/cookie-banner.njk
@@ -1,0 +1,77 @@
+{% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
+
+{% set cookiesMessageHtml %}
+  <p class="govuk-body">We’d like to use analytics cookies so we can understand how you use this website and make improvements.</p>
+{% endset %}
+
+{% set acceptMessageHtml %}
+  <p class="govuk-body">You’ve accepted analytics cookies. You can <a class="govuk-link" href="/cookies">change your cookie settings</a> at any time.</p>
+{% endset %}
+
+{% set rejectMessageHtml %}
+  <p class="govuk-body">You’ve rejected analytics cookies. You can <a class="govuk-link" href="/cookies">change your cookie settings</a> at any time.</p>
+{% endset %}
+
+{{ govukCookieBanner({
+  ariaLabel: "Cookies on GOV.UK Sign In",
+  attributes: {
+    style: "display: none"
+  },
+  messages: [
+    {
+      headingText: "Cookies on GOV.UK Sign In",
+      html: cookiesMessageHtml,
+      attributes: {
+        id: "cookies-banner-main"
+      },
+      actions: [
+        {
+          text: "Accept analytics cookies",
+          type: "button",
+          attributes: {
+            id: "cookiesAccept"
+          }
+        },
+        {
+          text: "Reject analytics cookies",
+          type: "button",
+          attributes: {
+            id: "cookiesReject"
+          }
+        },
+        {
+          text: "View cookies",
+          href: "/cookies"
+        }
+      ]
+    },
+    {
+      html: acceptMessageHtml,
+      role: "alert",
+      hidden: true,
+      attributes: {
+        id: "cookies-accepted"
+      },
+      actions: [
+        {
+          text: "Hide this message",
+          classes: "cookie-hide-button"
+        }
+      ]
+    },
+    {
+      html: rejectMessageHtml,
+      role: "alert",
+      hidden: true,
+        attributes: {
+        id: "cookies-rejected"
+      },
+      actions: [
+        {
+          text: "Hide this message",
+          classes: "cookie-hide-button"
+        }
+      ]
+    }
+  ]
+}) }}

--- a/express/src/views/create-account/check-email.njk
+++ b/express/src/views/create-account/check-email.njk
@@ -42,9 +42,7 @@
       } if errorMessages else false
     }) }}
 
-    <button id="submit" type="submit" class="govuk-button" data-module="govuk-button" formnovalidate>
-      Continue
-    </button>
+    {{ govukButton({ text: "Resend security code", attributes: {id: "submit"} }) }}
 
     <p class="govuk-body">
       <a id="resend-code-page" class="govuk-link" href="/create/resend-email-code">Not received an email?</a>

--- a/express/src/views/create-account/get-email.njk
+++ b/express/src/views/create-account/get-email.njk
@@ -46,8 +46,6 @@
       It sets out how we use your personal information.
     </p>
 
-    <button id="submit" type="submit" class="govuk-button" data-module="govuk-button">
-      Continue
-    </button>
+    {{ govukButton({ text: "Continue", attributes: {id: "submit"} }) }}
   </form>
 {% endblock %}

--- a/express/src/views/create-account/new-password.njk
+++ b/express/src/views/create-account/new-password.njk
@@ -1,5 +1,6 @@
 {% extends "../layout.njk" %}
 {% from "../macros/error-summary.njk" import errorSummary %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% set pageTitle = "Create your password" %}
 
@@ -19,19 +20,23 @@
          data-hide-full-text="Hide password" data-announce-show="Your password is shown"
          data-announce-hide="Your password is hidden">
 
-      <div class="govuk-form-group {% if errorMessages %}govuk-form-group--error{% endif %}">
-        <label for="password" class="gem-c-label govuk-label">Enter a password</label>
-        <div id="password-hint" class="gem-c-hint govuk-hint govuk-!-margin-bottom-3">
-          Must be at least 8 characters
-        </div>
-        {% if errorMessages %}
-          <p id="national-insurance-number-error" class="govuk-error-message">
-            <span class="govuk-visually-hidden">Error:</span> {{ errorMessages.password }}
-          </p>
-        {% endif %}
-        <input name="password" class="gem-c-input govuk-input govuk-!-width-two-thirds {% if errorMessages %}govuk-input--error{% endif %}"
-               id="password" type="password" autocomplete="new-password" aria-describedby="hint-password" value="{{ values.password }}">
-      </div>
+      {{ govukInput({
+        label: {
+          text: "Enter a password"
+        },
+        hint: {
+          text: "Must be at least 8 characters"
+        },
+        name: "password",
+        id: "password",
+        type: "password",
+        autocomplete: "new-password",
+        classes: "govuk-!-width-two-thirds gem-c-input",
+        value: values.password if values,
+        errorMessage: {
+          text:  errorMessages.password
+        } if  errorMessages
+      }) }}
     </div>
 
     {{ govukButton({ text: "Continue", attributes: {id: "submit"} }) }}

--- a/express/src/views/create-account/resend-email-code.njk
+++ b/express/src/views/create-account/resend-email-code.njk
@@ -14,9 +14,7 @@
   </p>
 
   <form method="post" action="/create/resend-email-code">
-    <button id="submit" type="submit" class="govuk-button" data-module="govuk-button">
-      Resend security code
-    </button>
+    {{ govukButton({ text: "Resend security code", attributes: {id: "submit"} }) }}
   </form>
 
   <p class="govuk-body">

--- a/express/src/views/create-account/resend-phone-code.njk
+++ b/express/src/views/create-account/resend-phone-code.njk
@@ -14,9 +14,7 @@
   </p>
 
   <form method="post" action="/create/resend-phone-code">
-    <button id="submit" type="submit" class="govuk-button" data-module="govuk-button">
-      Resend security code
-    </button>
+    {{ govukButton({ text: "Resend security code", attributes: {id: "submit"} }) }}
   </form>
 
   <p class="govuk-body">

--- a/express/src/views/index.njk
+++ b/express/src/views/index.njk
@@ -1,22 +1,9 @@
 {% extends "layout.njk" %}
+{% from "macros/breadcrumbs.njk" import breadcrumbs %}
+
+{% set breadcrumbs = breadcrumbs(currentPageName = "Register your services") %}
 
 {% block pageTitle %}Get started with GOV.UK Sign In{% endblock %}
-
-{% block beforeContent %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#">GOV.UK services</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#">GOV.UK Sign In</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item" style="font-weight: bold;">
-        Register your services
-      </li>
-    </ol>
-  </div>
-{% endblock %}
 
 {% block mainContent %}
   <h1 class="govuk-heading-l">Get started with GOV.UK Sign In</h1>

--- a/express/src/views/layout.njk
+++ b/express/src/views/layout.njk
@@ -98,11 +98,9 @@
 
       {% if showTopNav %}
         <div class="govuk-header__content">
-          <button type="button" role="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation">
-            Menu
-          </button>
-          <nav>
-            <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
+          <nav aria-label="Menu" class="govuk-header__navigation ">
+            <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide menu" hidden>Menu</button>
+            <ul id="navigation" class="govuk-header__navigation-list">
 
               {% if not isSignedIn %}
                 <li class="govuk-header__navigation-item{% if active == 'features' %} govuk-header__navigation-item--active{% endif %}">

--- a/express/src/views/layout.njk
+++ b/express/src/views/layout.njk
@@ -15,61 +15,7 @@
 {% endblock %}
 
 {% block bodyStart %}
-  <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on GOV.UK Sign In" style="display: none">
-    <div class="govuk-cookie-banner__message govuk-width-container" id="cookies-banner-main">
-
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on GOV.UK Sign In</h2>
-          <div class="govuk-cookie-banner__content">
-            <p class="govuk-body">We’d like to use analytics cookies so we can understand how you use this website and make improvements.</p>
-          </div>
-        </div>
-      </div>
-
-      <div class="govuk-button-group">
-        <button id="cookiesAccept" type="button" class="govuk-button" data-module="govuk-button">
-          Accept analytics cookies
-        </button>
-        <button id="cookiesReject" type="button" class="govuk-button" data-module="govuk-button">
-          Reject analytics cookies
-        </button>
-        <a class="govuk-link" href="/cookies">View cookies</a>
-      </div>
-    </div>
-
-    <div class="govuk-cookie-banner__message govuk-width-container" id="cookies-accepted" role="alert" hidden>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <div class="govuk-cookie-banner__content">
-            <p class="govuk-body">You’ve accepted analytics cookies. You can <a class="govuk-link" href="/cookies">change your cookie settings</a> at any time.</p>
-          </div>
-        </div>
-      </div>
-
-      <div class="govuk-button-group">
-        <button class="govuk-button cookie-hide-button" data-module="govuk-button">
-          Hide this message
-        </button>
-      </div>
-    </div>
-
-    <div class="govuk-cookie-banner__message govuk-width-container" id="cookies-rejected" role="alert" hidden>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <div class="govuk-cookie-banner__content">
-            <p class="govuk-body">You’ve rejected analytics cookies. You can <a class="govuk-link" href="/cookies">change your cookie settings</a> at any time.</p>
-          </div>
-        </div>
-      </div>
-
-      <div class="govuk-button-group">
-        <button class="govuk-button cookie-hide-button" data-module="govuk-button">
-          Hide this message
-        </button>
-      </div>
-    </div>
-  </div>
+  {%  include "common/cookie-banner.njk" %}
 {% endblock %}
 
 {% block beforeContent %}
@@ -104,44 +50,30 @@
 
               {% if not isSignedIn %}
                 <li class="govuk-header__navigation-item{% if active == 'features' %} govuk-header__navigation-item--active{% endif %}">
-                  <a class="govuk-header__link" href="https://www.sign-in.service.gov.uk/features">
-                    Features
-                  </a>
+                  <a class="govuk-header__link" href="https://www.sign-in.service.gov.uk/features">Features</a>
                 </li>
               {% endif %}
 
               <li class="govuk-header__navigation-item{% if active == 'documentation' %} govuk-header__navigation-item--active{% endif %}">
-                <a class="govuk-header__link" href="https://www.sign-in.service.gov.uk/documentation">
-                  Documentation
-                </a>
+                <a class="govuk-header__link" href="https://www.sign-in.service.gov.uk/documentation">Documentation</a>
               </li>
               <li class="govuk-header__navigation-item{% if active == 'support' %} govuk-header__navigation-item--active{% endif %}">
-                <a class="govuk-header__link" href="https://www.sign-in.service.gov.uk/support">
-                  Support
-                </a>
+                <a class="govuk-header__link" href="https://www.sign-in.service.gov.uk/support">Support</a>
               </li>
 
               {% if isSignedIn %}
                 <li class="govuk-header__navigation-item{% if active == 'your-account' %} govuk-header__navigation-item--active{% endif %}">
-                  <a class="govuk-header__link" href="/account">
-                    Your account
-                  </a>
+                  <a class="govuk-header__link" href="/account">Your account</a>
                 </li>
                 <li class="govuk-header__navigation-item">
-                  <a class="govuk-header__link" href="/account/sign-out">
-                    Sign out
-                  </a>
+                  <a class="govuk-header__link" href="/account/sign-out">Sign out</a>
                 </li>
               {% else %}
                 <li class="govuk-header__navigation-item{% if active == 'get-started' %} govuk-header__navigation-item--active{% endif %}">
-                  <a class="govuk-header__link" href="/">
-                    Get started
-                  </a>
+                  <a class="govuk-header__link" href="/">Get started</a>
                 </li>
                 <li class="govuk-header__navigation-item{% if active == 'sign-in' %} govuk-header__navigation-item--active{% endif %}">
-                  <a class="govuk-header__link" href="/sign-in">
-                    Sign in
-                  </a>
+                  <a class="govuk-header__link" href="/sign-in">Sign in</a>
                 </li>
               {% endif %}
             </ul>

--- a/express/src/views/layout.njk
+++ b/express/src/views/layout.njk
@@ -4,7 +4,7 @@
 
 {% set assetPath = "/dist" %}
 {% set showTopNav = showTopNav | default(true) %}
-{% set mainClasses = ["govuk-main-wrapper--auto-spacing", baseClasses | default("govuk-!-padding-top-6"), mainClasses] | join(" ") %}
+{% set mainClasses = ["govuk-main-wrapper--auto-spacing", mainClasses] | join(" ") %}
 
 {% block pageTitle %}{{ pageTitle }} - GOV.UK Sign In{% endblock %}
 

--- a/express/src/views/macros/breadcrumbs.njk
+++ b/express/src/views/macros/breadcrumbs.njk
@@ -1,0 +1,33 @@
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+{% macro breadcrumbs(intermediateCrumbs, currentPageName, classes) %}
+  {% set crumbs = [
+    {
+      text: "GOV.UK services",
+      href: "https://www.gov.uk/service-toolkit#gov-uk-services"
+    },
+    {
+      text: "GOV.UK Sign In",
+      href: "https://www.sign-in.service.gov.uk/"
+    }
+  ] %}
+
+  {% for crumb in intermediateCrumbs %}
+    {% set crumbs = (crumbs.push(crumb), crumbs) %}
+  {% endfor %}
+
+  {% if currentPageName %}
+    {% set crumbs = (crumbs.push({
+      text: currentPageName,
+      href: "#main-content",
+      attributes: {
+        "aria-current": "page"
+      }
+    }), crumbs) %}
+  {% endif %}
+
+  {{ govukBreadcrumbs({
+    items: crumbs,
+    classes: classes
+  }) }}
+{% endmacro %}

--- a/express/src/views/resend-phone-code-sign-in.njk
+++ b/express/src/views/resend-phone-code-sign-in.njk
@@ -13,9 +13,7 @@
   </p>
 
   <form method="post" action="/resend-text-code">
-    <button id="submit" type="submit" class="govuk-button" data-module="govuk-button">
-      Resend security code
-    </button>
+    {{ govukButton({ text: "Resend security code", attributes: {id: "submit"} }) }}
   </form>
 
   <p class="govuk-body">

--- a/express/src/views/security-check-change-number.njk
+++ b/express/src/views/security-check-change-number.njk
@@ -43,9 +43,7 @@
       } if errorMessages else false
     }) }}
 
-    <button id="submit" type="submit" class="govuk-button" data-module="govuk-button" formnovalidate>
-      Continue
-    </button>
+    {{ govukButton({ text: "Resend security code", attributes: {id: "submit"} }) }}
 
     <p class="govuk-body"><a id="resend-code-page" class="govuk-link" href="/resend-email-code">Problems receiving an email?</a></p>
   </form>

--- a/express/src/views/service-details/change-public-key-v2.njk
+++ b/express/src/views/service-details/change-public-key-v2.njk
@@ -28,12 +28,10 @@
   </p>
 
   {% if currentPublicKey %}
-    {% set currentPublicKeyBlock %}
+    {% call govukInsetText() %}
       <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">Current public key</p>
       <p class="govuk-body current-public-key-container">{{ currentPublicKey }}</p>
-    {% endset -%}
-
-    {{ govukInsetText({ html: currentPublicKeyBlock }) }}
+    {% endcall %}
   {% endif %}
 
   <form class="form" action="/change-public-key-v2/{{ serviceId }}/{{ selfServiceClientId }}/{{ clientId }}" method="post">

--- a/express/src/views/service-details/client-details.njk
+++ b/express/src/views/service-details/client-details.njk
@@ -15,7 +15,7 @@
     {% endcall %}
   {% endif %}
 
-  <h1 class="govuk-heading-l govuk-!-margin-top-3">Client details</h1>
+  <h1 class="govuk-heading-l">Client details</h1>
   <p class="govuk-body">This page shows the information you’ll need to make calls to the GOV.UK Sign In API.</p>
   <p class="govuk-body">You can use the client details to
     <a href="https://auth-tech-docs.london.cloudapps.digital/integrate-with-integration-environment/integrate-with-code-flow/#make-an-authorisation-request"
@@ -26,13 +26,12 @@
   {{ govukTag({ text: "Integration", classes: "govuk-tag--yellow" }) }}
 
   {% if publicKeyAndUrlsNotUpdatedByUser %}
-    <div class="govuk-inset-text govuk-!-margin-top-3 govuk-!-margin-bottom-0">
+    <div class="govuk-inset-text govuk-!-margin-top-3 govuk-!-margin-bottom-3">
       We’ve generated these details based on the service name you gave us.
     </div>
   {% endif %}
 
   {{ govukSummaryList({
-    classes: 'govuk-!-padding-top-3',
     rows: [
       {
         key: {text: "Client name"},

--- a/express/src/views/service-details/client-details.njk
+++ b/express/src/views/service-details/client-details.njk
@@ -8,17 +8,11 @@
 
 {% block mainContent %}
   {% if updatedField %}
-    {% set htmlNotificationBanner %}
+    {% call govukNotificationBanner({type: 'success'}) %}
       <h3 class="govuk-notification-banner__heading">
         You have changed your {{ updatedField }}
       </h3>
-    {% endset %}
-
-    {{ govukNotificationBanner({
-      classes: 'govuk-!-margin-bottom-5',
-      html: htmlNotificationBanner,
-      type: 'success'
-    }) }}
+    {% endcall %}
   {% endif %}
 
   <h1 class="govuk-heading-l govuk-!-margin-top-3">Client details</h1>

--- a/express/src/views/service-details/layout-service-details.njk
+++ b/express/src/views/service-details/layout-service-details.njk
@@ -1,11 +1,10 @@
 {% extends "../layout.njk" %}
 
-{% set mainClasses = "left-nav-wrapper" %}
-{% set baseClasses = "govuk-!-padding-top-3" %}
+{% set mainClasses = "govuk-!-padding-top-5 left-nav-wrapper" %}
 
 {% block beforeContent %}
-  <div class="govuk-body govuk-!-font-weight-bold">My juggling service</div>
-  <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible govuk-!-margin-bottom-5">
+  <div class="govuk-body govuk-!-padding-top-3 govuk-!-font-weight-bold">My juggling service</div>
+  <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
 {% endblock %}
 
 {% block content %}

--- a/express/src/views/service-details/private-beta.njk
+++ b/express/src/views/service-details/private-beta.njk
@@ -21,7 +21,7 @@
   <p class="govuk-body">Discuss our
     <a class="govuk-link" rel="noreferrer noopener" target="_blank"
        href="https://www.sign-in.service.gov.uk/getting-started/private-beta">
-      private beta guidance (opens in new tab)</a> with your team to see if it's right for you.
+      private beta guidance (opens in new tab)</a> with your team to see if it’s right for you.
   </p>
 
   <h2 class="govuk-heading-m">Speak to us about joining private beta</h2>

--- a/express/src/views/service-details/private-beta.njk
+++ b/express/src/views/service-details/private-beta.njk
@@ -66,26 +66,18 @@
       {{ govukSummaryList({
         rows: [
           {
-            key: {
-            text: "Email address"
-          },
-            value: {
-            text: emailAddress
-          }
+            key: {text: "Email address"},
+            value: {text: emailAddress}
           },
           {
-            key: {
-            text: "Service name"
-          },
-            value: {
-            text: serviceName
-          }
+            key: {text: "Service name"},
+            value: {text: serviceName}
           }
         ]
       }) }}
 
-      <input type="hidden" value="{{ serviceName }}" id="serviceName" name="serviceName">
-      <input type="hidden" value="{{ emailAddress }}" id="emailAddress" name="emailAddress">
+      {{ govukInput({ type: "hidden", value: serviceName, id: "serviceName", name: "serviceName" }) }}
+      {{ govukInput({ type: "hidden", value: emailAddress, id: "emailAddress", name: "emailAddress" }) }}
 
       {{ govukButton({ text: "Submit" }) }}
     </form>

--- a/express/src/views/sign-in-enter-password.njk
+++ b/express/src/views/sign-in-enter-password.njk
@@ -1,6 +1,7 @@
 {% extends "./layout.njk" %}
 {% from "macros/back-link.njk" import backLink %}
 {% from "macros/error-summary.njk" import errorSummary %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% set active = "sign-in" %}
 {% set backLink = backLink("/sign-in") %}
@@ -22,16 +23,20 @@
          data-hide-full-text="Hide password" data-announce-show="Your password is shown"
          data-announce-hide="Your password is hidden">
 
-      <div class="govuk-form-group {% if errorMessages %}govuk-form-group--error{% endif %}">
-        <label for="password" class="gem-c-label govuk-label">Password</label>
-        {% if errorMessages %}
-          <span class="govuk-error-message">
-            <span class="govuk-visually-hidden">Error:</span> {{ errorMessages.password }}
-          </span>
-        {% endif %}
-        <input name="password" class="gem-c-input govuk-input govuk-!-width-two-thirds {% if errorMessages %}govuk-input--error{% endif %}"
-               id="password" type="password" autocomplete="new-password" aria-describedby="hint-password" value="{{ values?.password }}">
-      </div>
+      {{ govukInput({
+        label: {
+          text: "Password"
+        },
+        name: "password",
+        id: "password",
+        type: "password",
+        autocomplete: "new-password",
+        classes: "govuk-!-width-two-thirds gem-c-input",
+        value: values.password if values,
+        errorMessage: {
+          text:  errorMessages.password
+        } if  errorMessages
+      }) }}
     </div>
 
     {{ govukButton({ text: "Continue", attributes: {id: "continue"} }) }}

--- a/express/src/views/sign-in.njk
+++ b/express/src/views/sign-in.njk
@@ -32,8 +32,6 @@
       value: values?.emailAddress if values
     }) }}
 
-    <button id="submit" type="submit" class="govuk-button" data-module="govuk-button">
-      Continue
-    </button>
+    {{ govukButton({ text: "Continue", attributes: {id: "submit"} }) }}
   </form>
 {% endblock %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "express": "^4.17.1",
         "express-async-errors": "^3.1.1",
         "express-session": "^1.17.2",
-        "govuk-frontend": "^3.13.1",
+        "govuk-frontend": "^4.3.1",
         "node-sass-package-importer": "^5.3.2",
         "nodemon": "^2.0.19",
         "nunjucks": "^3.2.3",
@@ -7782,9 +7782,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.3.1.tgz",
+      "integrity": "sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -19505,7 +19505,7 @@
         "express": "^4.17.1",
         "express-async-errors": "^3.1.1",
         "express-session": "^1.17.2",
-        "govuk-frontend": "^3.13.1",
+        "govuk-frontend": "^4.3.1",
         "node-sass": "^7.0.1",
         "node-sass-package-importer": "^5.3.2",
         "nodemon": "^2.0.19",
@@ -19690,9 +19690,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.3.1.tgz",
+      "integrity": "sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A=="
     },
     "graceful-fs": {
       "version": "4.2.10",


### PR DESCRIPTION
- Upgrade to the latest version of the GOV.UK Design System 
  See release notes for 4.0.0
  https://github.com/alphagov/govuk-frontend/releases/tag/v4.0.0

- Use standard spacing on all views as per the GOV.UK Design System 
  Remove custom top and bottom spacing and let the design system handle that.
  https://design-system.service.gov.uk/styles/layout/

- Use govuk components where possible instead of HTML