### PR TITLE
DFA-2048: Add workflow to push frontend Docker image to ECR

### DIFF
--- a/.github/workflows/build-front-app.yml
+++ b/.github/workflows/build-front-app.yml
@@ -3,7 +3,7 @@ name: Build
 on: workflow_call
 
 concurrency:
-  group: build-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: build-front-app-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-front-image.yml
+++ b/.github/workflows/build-front-image.yml
@@ -1,0 +1,35 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      environment: { required: true, type: string }
+    secrets:
+      aws-role-arn: { required: true }
+
+concurrency:
+  group: build-front-image-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Frontend image
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Pull repository
+        uses: actions/checkout@v3
+
+      - name: Build Docker image
+        uses: alphagov/di-github-actions/aws/ecr/build-docker-image@44aea56aa4d76d27118d1485de4170cd9ac4c0f4
+        with:
+          aws-role-arn: ${{ secrets.aws-role-arn }}
+          repository: self-service/frontend
+          image-version: ${{ github.sha }}
+          image-tags: ${{ github.head_ref || github.ref_name }}
+          build-path: express

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Run checkov
-        uses: alphagov/di-github-actions/code-quality/run-checkov@5081bd9e9345438973363015b73e976b4d844bb3
+        uses: alphagov/di-github-actions/code-quality/run-checkov@44aea56aa4d76d27118d1485de4170cd9ac4c0f4
 
   check-shell-scripts:
     name: Shell scripts
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Run shell checks
-        uses: alphagov/di-github-actions/code-quality/check-shell-scripts@5081bd9e9345438973363015b73e976b4d844bb3
+        uses: alphagov/di-github-actions/code-quality/check-shell-scripts@44aea56aa4d76d27118d1485de4170cd9ac4c0f4
 
   check-linting:
     name: Linting
@@ -33,4 +33,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check linting and formatting
-        uses: alphagov/di-github-actions/code-quality/check-linting@5081bd9e9345438973363015b73e976b4d844bb3
+        uses: alphagov/di-github-actions/code-quality/check-linting@44aea56aa4d76d27118d1485de4170cd9ac4c0f4

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -9,7 +9,7 @@ jobs:
 
   build-front:
     name: Build
-    uses: ./.github/workflows/build-front.yml
+    uses: ./.github/workflows/build-front-app.yml
 
   run-unit-tests:
     name: Run tests

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -18,7 +18,7 @@ jobs:
     environment: preview
     steps:
       - name: PaaS login
-        uses: alphagov/di-github-actions/paas/log-in-to-paas@5081bd9e9345438973363015b73e976b4d844bb3
+        uses: alphagov/di-github-actions/paas/log-in-to-paas@44aea56aa4d76d27118d1485de4170cd9ac4c0f4
         with:
           cf-org-name: gds-digital-identity-onboarding
           cf-space-name: self-service-preview
@@ -27,7 +27,7 @@ jobs:
 
       - name: Get app name
         if: ${{ github.event_name != 'schedule' }}
-        uses: alphagov/di-github-actions/beautify-branch-name@5081bd9e9345438973363015b73e976b4d844bb3
+        uses: alphagov/di-github-actions/beautify-branch-name@44aea56aa4d76d27118d1485de4170cd9ac4c0f4
         with:
           downcase: true
           length-limit: 63
@@ -42,6 +42,6 @@ jobs:
 
       - name: Clean up stale deployments
         if: ${{ github.event_name == 'schedule' }}
-        uses: alphagov/di-github-actions/paas/delete-stale-apps@5081bd9e9345438973363015b73e976b4d844bb3
+        uses: alphagov/di-github-actions/paas/delete-stale-apps@44aea56aa4d76d27118d1485de4170cd9ac4c0f4
         with:
           age-threshold-days: 30

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -1,15 +1,26 @@
-name: Deploy branch
+name: Deploy branch preview
 
 on: workflow_dispatch
 
 jobs:
-  build-front:
+  build-front-app:
     name: Build
-    uses: ./.github/workflows/build-front.yml
+    uses: ./.github/workflows/build-front-app.yml
 
-  deploy-front-preview:
+  build-front-image:
+    name: Build
+    uses: ./.github/workflows/build-front-image.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      environment: development
+    secrets:
+      aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}
+
+  deploy-front-preview-paas:
     name: Preview
-    needs: build-front
+    needs: build-front-app
     uses: ./.github/workflows/deploy-to-paas.yml
     with:
       environment: preview

--- a/.github/workflows/deploy-to-paas.yml
+++ b/.github/workflows/deploy-to-paas.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Push to PaaS
         id: push-to-paas
-        uses: alphagov/di-github-actions/paas/deploy-app@5081bd9e9345438973363015b73e976b4d844bb3
+        uses: alphagov/di-github-actions/paas/deploy-app@44aea56aa4d76d27118d1485de4170cd9ac4c0f4
         with:
           app-name-prefix: ${{ inputs.app-name-prefix }}
           cf-org-name: gds-digital-identity-onboarding

--- a/.github/workflows/deploy-to-paas.yml
+++ b/.github/workflows/deploy-to-paas.yml
@@ -20,7 +20,7 @@ on:
         value: ${{ jobs.deploy.outputs.deployment-url }}
 
 concurrency:
-  group: deploy-${{ github.head_ref || github.ref_name }}
+  group: deploy-paas-${{ github.head_ref || github.ref_name }}
 
 jobs:
   deploy:

--- a/ci/github-actions-role.yml
+++ b/ci/github-actions-role.yml
@@ -42,6 +42,7 @@ Resources:
                   - ecr:CompleteLayerUpload
                   - ecr:UploadLayerPart
                   - ecr:BatchCheckLayerAvailability
+                  - ecr:BatchDeleteImage
                   - ecr:BatchGetImage
                   - ecr:ListImages
                   - ecr:PutImage

--- a/express/assets/css/app.scss
+++ b/express/assets/css/app.scss
@@ -179,14 +179,11 @@ code {
   padding: 24px 24px 0 24px;
 }
 
-main.main-existing-account {
-  padding-top: 15px;
-}
-
 #publicKeyContainer {
   #publicKeyLong {
     display: none;
   }
+
   #togglePublicKey {
     border: none;
     background: none;
@@ -196,13 +193,15 @@ main.main-existing-account {
     padding-left: 0;
     margin-bottom: 0;
   }
+
   #togglePublicKey:hover {
     box-shadow: none;
   }
+
   #togglePublicKey:focus {
     color: $govuk-text-colour;
     background-color: $govuk-focus-colour;
-    -webkit-box-shadow: 0 -2px  $govuk-focus-colour,0 4px $govuk-text-colour;
+    -webkit-box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-text-colour;
     box-shadow: rgb(255, 221, 0) 0px -2px, rgb(11, 12, 12) 0px 4px;
   }
 }

--- a/express/src/views/create-account/existing-account.njk
+++ b/express/src/views/create-account/existing-account.njk
@@ -5,8 +5,6 @@
 
 {% set backLink = backLink("/create/get-email") %}
 {% set pageTitle = "An account already exists" %}
-{% set mainClasses = "main-existing-account" %}
-
 
 {% block mainContent %}
   {{ errorSummary ({


### PR DESCRIPTION
**_Note: This PR needs shared actions from alphagov/di-github-actions#25_**

**DFA-2048: Add a workflow to build and push frontend image to ECR**

The workflow builds and pushes frontend images for preview deployments.

Each image is versioned with the git SHA and additionally has the current branch tag. Since the repository is immutable, only one image per branch is allowed. The previous version for a branch, if it exists, is deleted before pushing a newer one.

Images are built and pushed when a branch is deployed manually (for now).

---

- DFA-2036: Remove custom padding
  Use standard design system padding on the 'account already exists' page
