### PR TITLE
BAU simulate wrong password

### DIFF
--- a/express/src/services/cognito/StubCognitoClient.ts
+++ b/express/src/services/cognito/StubCognitoClient.ts
@@ -6,6 +6,7 @@ import {
     ChangePasswordCommandOutput,
     CodeMismatchException,
     GetUserAttributeVerificationCodeCommandOutput,
+    NotAuthorizedException,
     RespondToAuthChallengeCommandOutput,
     UsernameExistsException,
     VerifyUserAttributeCommandOutput
@@ -202,6 +203,8 @@ export class CognitoClient implements CognitoInterface {
                 return new UsernameExistsException({$metadata: {}});
             case "CodeMismatchException":
                 return new CodeMismatchException({$metadata: {}});
+            case "NotAuthorizedException":
+                return new NotAuthorizedException({$metadata: {}});
         }
         throw new Error("Unknown exception");
     }

--- a/express/stub/stubs-config.json
+++ b/express/stub/stubs-config.json
@@ -44,6 +44,11 @@
       "return": {
         "Session": "Some or other arbitrary non-null value"
       }
+    },
+    {
+      "parameter": "email",
+      "value": "password-will-be-wrong@stub.gov.uk",
+      "throw": "NotAuthorizedException"
     }
   ],
   "respondToMfaChallenge": [


### PR DESCRIPTION
Add some stubbed stuff so we can pretend the user entered the wrong password.

Because of the limitations of the stubs we have to use an email for the value to detect.  These will probably be refactored so not much point in doing anything extra.