### PR TITLE
DFA-2341: Fixes for the account/service details area of the admin tool

### DIFF
--- a/.github/workflows/build-front-app.yml
+++ b/.github/workflows/build-front-app.yml
@@ -23,7 +23,7 @@ jobs:
           cache: "npm"
 
       - name: Install Node dependencies
-        run: npm install
+        run: npm install --include-workspace-root
 
       - name: Build app
         run: npm run build

--- a/backend/dynamo-api/package.json
+++ b/backend/dynamo-api/package.json
@@ -8,7 +8,6 @@
     "test": "jest --silent"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.160.0",
     "@aws-sdk/client-lambda": "^3.160.0",
     "@aws-sdk/client-sfn": "^3.160.0",
     "@aws-sdk/client-sns": "^3.162.0",

--- a/express/src/app.ts
+++ b/express/src/app.ts
@@ -46,21 +46,19 @@ declare module "express-session" {
     interface SessionData {
         emailAddress: string;
         mobileNumber: string;
-        enteredMobileNumber: string;
         cognitoSession: string;
+        isSignedIn: boolean;
         authenticationResult: AuthenticationResultType;
+        enteredMobileNumber: string;
         mfaResponse: MfaResponse;
         updatedField: string;
-        isSignedIn: boolean;
+        serviceName: string;
     }
 }
 
 configureViews(app);
 
 app.use(setSignedInStatus);
-app.use(function (req: Request, res: Response, next: NextFunction) {
-    next();
-});
 
 app.use("/", createAccount);
 app.use("/", signIn);

--- a/express/src/controllers/manage-account.ts
+++ b/express/src/controllers/manage-account.ts
@@ -83,6 +83,71 @@ export const showClient = async function (req: Request, res: Response) {
     req.session.updatedField = undefined;
 };
 
+export const showPrivateBetaForm = async function (req: Request, res: Response) {
+    res.render("service-details/private-beta.njk", {
+        serviceId: req.params.serviceId,
+        selfServiceClientId: req.params.selfServiceClientId,
+        clientId: req.params.clientId,
+        serviceName: req.session.serviceName,
+        emailAddress: req.session.emailAddress
+    });
+};
+
+export const processPrivateBetaForm = async function (req: Request, res: Response) {
+    const yourName = req.body.yourName;
+    const department = req.body.department;
+    const serviceName = req.body.serviceName;
+    const emailAddress = req.session.emailAddress;
+    const serviceId = req.params.serviceId;
+    const selfServiceClientId = req.params.selfServiceClientId;
+    const clientId = req.params.clientId;
+    const errorMessages = new Map<string, string>();
+
+    if (yourName === "") {
+        errorMessages.set("yourName", "Enter your name");
+    }
+
+    if (department === "") {
+        errorMessages.set("department", "Enter your department");
+    }
+
+    if (errorMessages.size > 0) {
+        res.render("service-details/private-beta.njk", {
+            serviceId: serviceId,
+            selfServiceClientId: selfServiceClientId,
+            clientId: clientId,
+            serviceName: serviceName,
+            emailAddress: emailAddress,
+            errorMessages: Object.fromEntries(errorMessages),
+            values: {
+                yourName: yourName,
+                department: department
+            }
+        });
+
+        return;
+    }
+
+    const s4: SelfServiceServicesService = req.app.get("backing-service");
+    await s4.privateBetaRequest(
+        yourName,
+        department,
+        serviceName,
+        emailAddress as string,
+        req.session.authenticationResult?.AccessToken as string
+    );
+
+    res.redirect(`/private-beta-form-submitted/${serviceId}/${selfServiceClientId}/${clientId}`);
+};
+
+export const showPrivateBetaFormSubmitted = async function (req: Request, res: Response) {
+    res.render("service-details/private-beta-form-submitted.njk", {
+        serviceId: req.params.serviceId,
+        selfServiceClientId: req.params.selfServiceClientId,
+        clientId: req.params.clientId
+    });
+};
+
 export const showAddServiceForm = async function (req: Request, res: Response) {
     res.render("add-service-name.njk");
 };

--- a/express/src/controllers/manage-account.ts
+++ b/express/src/controllers/manage-account.ts
@@ -116,14 +116,13 @@ export const processAddServiceForm = async function (req: Request, res: Response
     res.redirect(`/client-details/${serviceId.substring(8)}`);
 };
 
-export const processUpdateServiceForm = async function (req: Request, res: Response) {
-    const serviceName = req.body.serviceName;
-    const selfServiceClientId = req.body.selfServiceClientId;
-    const clientId = req.body.clientId;
-    const clientServiceId = req.body.clientServiceId;
+export const processChangeServiceNameForm = async function (req: Request, res: Response) {
+    const newServiceName = req.body.serviceName;
+    const serviceId = req.params.serviceId;
 
-    if (serviceName === "") {
+    if (newServiceName === "") {
         res.render("account/change-service-name.njk", {
+            serviceId: serviceId,
             errorMessages: {
                 serviceName: "Enter your service name"
             }
@@ -132,24 +131,22 @@ export const processUpdateServiceForm = async function (req: Request, res: Respo
         return;
     }
 
-    const userId = AuthenticationResultParser.getCognitoId(req.session.authenticationResult as AuthenticationResultType);
-    if (userId === undefined) {
-        console.log("Can't get CognitoId from authenticationResult in session");
-        res.render("there-is-a-problem.njk");
-        return;
-    }
-
+    const selfServiceClientId = req.params.selfServiceClientId;
+    const clientId = req.params.clientId;
     const s4: SelfServiceServicesService = req.app.get("backing-service");
+
+    // TODO service_name is the db layer leaking into the domain
+    // TODO is this correct? Don't we also need to update the pk:service sk:service entry? We need an updateService call
     await s4.updateClient(
+        serviceId,
         selfServiceClientId,
-        clientServiceId,
         clientId,
-        {client_name: serviceName},
+        {service_name: newServiceName},
         req.session.authenticationResult?.AccessToken as string
     );
 
     req.session.updatedField = "service name";
-    res.redirect(`/client-details/${selfServiceClientId}`);
+    res.redirect(`/client-details/${serviceId}`);
 };
 
 export const showChangePasswordForm = async function (req: Request, res: Response) {

--- a/express/src/lib/validators/checkOtp.ts
+++ b/express/src/lib/validators/checkOtp.ts
@@ -12,6 +12,7 @@ export function validateOtp(otp: string): validationResult {
     if (notJustDigits(otp)) {
         return {isValid: false, errorMessage: "Your security code should only include numbers"};
     }
+
     return {isValid: true};
 }
 

--- a/express/src/middleware/validators/mobileOtpValidator.ts
+++ b/express/src/middleware/validators/mobileOtpValidator.ts
@@ -31,7 +31,7 @@ export function mobileOtpValidator(
                     textMessageNotReceivedUrl: textMessageNotReceivedUrl
                 },
                 errorMessages: {
-                    "sms-otp": validationResponse.errorMessage as string
+                    "sms-otp": validationResponse.errorMessage
                 }
             });
         }

--- a/express/src/middleware/validators/urisValidator.ts
+++ b/express/src/middleware/validators/urisValidator.ts
@@ -13,13 +13,13 @@ export function urisValidator(template: string, whichUris: string): MiddlewareFu
             next();
         } else {
             res.render(template, {
+                serviceId: req.params.serviceId,
+                selfServiceClientId: req.params.selfServiceClientId,
+                clientId: req.params.clientId,
                 errorMessages: whichUris === "redirectUris" ? {redirectUris: result.errorMessage} : {postLogoutUris: result.errorMessage},
                 values: {
                     redirectURIs: req.body[whichUris],
-                    postLogoutURIs: req.body[whichUris],
-                    serviceId: req.params.serviceId,
-                    selfServiceClientId: req.params.selfServiceClientId,
-                    clientId: req.params.clientId
+                    postLogoutURIs: req.body[whichUris]
                 }
             });
         }

--- a/express/src/routes/manage-account.ts
+++ b/express/src/routes/manage-account.ts
@@ -4,7 +4,7 @@ import {
     listServices,
     processAddServiceForm,
     processChangePhoneNumberForm,
-    processUpdateServiceForm,
+    processChangeServiceNameForm,
     showAccount,
     showAddServiceForm,
     showChangePasswordForm,
@@ -39,23 +39,26 @@ router.post(
     changePassword
 );
 
-router.get("/change-phone-number", showChangePhoneNumberForm);
+router.get("/change-phone-number", checkAuthorisation, showChangePhoneNumberForm);
 
-router.post("/change-phone-number", validateMobileNumber("account/change-phone-number.njk"), processChangePhoneNumberForm);
+router.post(
+    "/change-phone-number",
+    checkAuthorisation,
+    validateMobileNumber("account/change-phone-number.njk"),
+    processChangePhoneNumberForm
+);
 
-router.post("/verify-phone-code", mobileOtpValidator("/verify-phone-code", ""), verifyMobileWithSmsCode);
+router.post("/verify-phone-code", checkAuthorisation, mobileOtpValidator("/verify-phone-code", ""), verifyMobileWithSmsCode);
 
-router.get("/change-service-name/:serviceName/:selfServiceClientId/:authClientId/:clientServiceId", (req, res) => {
+router.get("/change-service-name/:serviceId/:selfServiceClientId/:clientId", checkAuthorisation, (req, res) => {
     res.render("account/change-service-name.njk", {
+        serviceId: req.params.serviceId,
         values: {
-            serviceName: req.params.serviceName,
-            clientServiceId: req.params.clientServiceId,
-            selfServiceClientId: req.params.selfServiceClientId,
-            clientId: req.params.authClientId
+            serviceName: req.query.serviceName
         }
     });
 });
 
-router.post("/change-service-name", processUpdateServiceForm);
+router.post("/change-service-name/:serviceId/:selfServiceClientId/:clientId", checkAuthorisation, processChangeServiceNameForm);
 
 export default router;

--- a/express/src/routes/manage-account.ts
+++ b/express/src/routes/manage-account.ts
@@ -9,15 +9,14 @@ import {
     showAddServiceForm,
     showChangePasswordForm,
     showChangePhoneNumberForm,
+    showClient,
     verifyMobileWithSmsCode
 } from "../controllers/manage-account";
 import {checkAuthorisation} from "../middleware/authoriser";
 import {mobileOtpValidator} from "../middleware/validators/mobileOtpValidator";
+import validateMobileNumber from "../middleware/validators/mobileValidator";
 import notOnCommonPasswordListValidator from "../middleware/validators/notOnCommonPasswordListValidator";
 import {serviceNameValidator} from "../middleware/validators/serviceNameValidator";
-import validateMobileNumber from "../middleware/validators/mobileValidator";
-import SelfServiceServicesService from "../services/self-service-services-service";
-import {Client} from "../../@types/client";
 
 const router = express.Router();
 
@@ -28,47 +27,8 @@ router.get("/account/list-services", checkAuthorisation, listServices);
 router.get("/add-service-name", checkAuthorisation, showAddServiceForm);
 router.post("/create-service-name-validation", checkAuthorisation, serviceNameValidator, processAddServiceForm);
 
-router.get("/client-details/:serviceId", async (req, res) => {
-    const s4: SelfServiceServicesService = req.app.get("backing-service");
-    const listOfClients: Client[] = await s4.listClients(req.params.serviceId, req.session?.authenticationResult?.AccessToken as string);
-    const client: Client = listOfClients[0];
-    const selfServiceClientId = client.dynamoId;
-    const serviceId = client.dynamoServiceId;
-    const authClientId = client.authClientId;
-    res.render("service-details/client-details.njk", {
-        serviceId: req.params.serviceId,
-        clientServiceId: serviceId,
-        selfServiceClientId: selfServiceClientId,
-        authClientId: authClientId,
-        publicKeyAndUrlsNotUpdatedByUser: true,
-        updatedField: req.session.updatedField,
-        clientName: client.serviceName,
-        serviceName: client.serviceName,
-        clientId: client.authClientId,
-        redirectUrls: client.redirectUris.join(" "),
-        userAttributesRequired: client.scopes.join(", "),
-        userPublicKey: client.publicKey == DEFAULT_PUBLIC_KEY ? "" : client.publicKey,
-        postLogoutRedirectUrls: client.logoutUris.join(" "),
-        urls: {
-            changeClientName: `/change-client-name/${selfServiceClientId}/${serviceId}/${authClientId}?clientName=${encodeURI(
-                client.serviceName
-            )}`,
-            changeRedirectUris: `/change-redirect-uris/${selfServiceClientId}/${serviceId}/${authClientId}?redirectUris=${encodeURI(
-                client.redirectUris.join(" ")
-            )}`,
-            changeUserAttributes: `/change-user-attributes/${selfServiceClientId}/${serviceId}/${authClientId}?userAttributes=${encodeURI(
-                client.scopes.join(" ")
-            )}`,
-            changePublicKey: `/change-public-key/${selfServiceClientId}/${serviceId}/${authClientId}?publicKey=${encodeURI(
-                client.publicKey
-            )}`,
-            changePostLogoutUris: `/change-post-logout-uris/${selfServiceClientId}/${serviceId}/${authClientId}?redirectUris=${encodeURI(
-                client.logoutUris.join(" ")
-            )}`
-        }
-    });
-    req.session.updatedField = undefined;
-});
+// TODO This should have params :serviceId/:clientId but at the moment we're abusing the fact that each service only has one client
+router.get("/client-details/:serviceId", checkAuthorisation, showClient);
 
 router.get("/change-password", checkAuthorisation, showChangePasswordForm);
 
@@ -97,8 +57,5 @@ router.get("/change-service-name/:serviceName/:selfServiceClientId/:authClientId
 });
 
 router.post("/change-service-name", processUpdateServiceForm);
-
-const DEFAULT_PUBLIC_KEY =
-    "MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAp2mLkQGo24Kz1rut0oZlviMkGomlQCH+iT1pFvegZFXq39NPjRWyatmXp/XIUPqCq9Kk8/+tq4Sgjw+EM5tATJ06j5r+35of58ATGVPniW//IhGizrv6/ebGcGEUJ0Y/ZmlCHYPV+lbewpttQ/IYKM1nr3k/Rl6qepbVYe+MpGubluQvdhgUYel9OzxiOvUk7XI0axPquiXzoEgmNNOai8+WhYTkBqE3/OucAv+XwXdnx4XHmKzMwTv93dYMpUmvTxWcSeEJ/4/SrbiK4PyHWVKU2BozfSUejVNhahAzZeyyDwhYJmhBaZi/3eOOlqGXj9UdkOXbl3vcwBH8wD30O9/4F5ERLKxzOaMnKZ+RpnygWF0qFhf+UeFMy+O06sdgiaFnXaSCsIy/SohspkKiLjNnhvrDNmPLMQbQKQlJdcp6zUzI7Gzys7luEmOxyMpA32lDBQcjL7KNwM15s4ytfrJ46XEPZUXESce2gj6NazcPPsrTa/Q2+oLS9GWupGh7AgMBAAE=";
 
 export default router;

--- a/express/src/routes/manage-account.ts
+++ b/express/src/routes/manage-account.ts
@@ -5,11 +5,14 @@ import {
     processAddServiceForm,
     processChangePhoneNumberForm,
     processChangeServiceNameForm,
+    processPrivateBetaForm,
     showAccount,
     showAddServiceForm,
     showChangePasswordForm,
     showChangePhoneNumberForm,
     showClient,
+    showPrivateBetaForm,
+    showPrivateBetaFormSubmitted,
     verifyMobileWithSmsCode
 } from "../controllers/manage-account";
 import {checkAuthorisation} from "../middleware/authoriser";
@@ -29,6 +32,10 @@ router.post("/create-service-name-validation", checkAuthorisation, serviceNameVa
 
 // TODO This should have params :serviceId/:clientId but at the moment we're abusing the fact that each service only has one client
 router.get("/client-details/:serviceId", checkAuthorisation, showClient);
+
+router.get("/private-beta/:serviceId/:selfServiceClientId/:clientId", checkAuthorisation, showPrivateBetaForm);
+router.post("/private-beta/:serviceId/:selfServiceClientId/:clientId", checkAuthorisation, processPrivateBetaForm);
+router.get("/private-beta-form-submitted/:serviceId/:selfServiceClientId/:clientId", checkAuthorisation, showPrivateBetaFormSubmitted);
 
 router.get("/change-password", checkAuthorisation, showChangePasswordForm);
 

--- a/express/src/routes/testing-routes.ts
+++ b/express/src/routes/testing-routes.ts
@@ -1,9 +1,9 @@
 import express from "express";
 import {convertPublicKeyForAuth} from "../middleware/convertPublicKeyForAuth";
 import {emailValidator} from "../middleware/validators/emailValidator";
+import validateMobileNumber from "../middleware/validators/mobileValidator";
 import {passwordValidator} from "../middleware/validators/passwordValidator";
 import {urisValidator} from "../middleware/validators/urisValidator";
-import validateMobileNumber from "../middleware/validators/mobileValidator";
 import SelfServiceServicesService from "../services/self-service-services-service";
 
 const router = express.Router();
@@ -11,35 +11,38 @@ const router = express.Router();
 // Testing routes for Change your client name page
 router.get("/change-client-name/:serviceId/:selfServiceClientId/:clientId", (req, res) => {
     res.render("service-details/change-client-name.njk", {
+        serviceId: req.params.serviceId,
+        selfServiceClientId: req.params.selfServiceClientId,
+        clientId: req.params.clientId,
         values: {
-            clientName: req.query?.clientName,
-            serviceId: req.params.serviceId,
-            selfServiceClientId: req.params.selfServiceClientId,
-            clientId: req.params.clientId
+            clientName: req.query.clientName
         }
     });
 });
 
 router.post("/change-client-name/:serviceId/:selfServiceClientId/:clientId", async (req, res) => {
-    const clientName = req.body.clientName;
-    if (clientName === "") {
+    const newClientName = req.body.clientName;
+
+    if (newClientName === "") {
         res.render("service-details/change-client-name.njk", {
+            serviceId: req.params.serviceId,
+            selfServiceClientId: req.params.selfServiceClientId,
+            clientId: req.params.clientId,
             errorMessages: {
                 clientName: "Enter your client name"
-            },
-            values: {
-                clientId: req.params.clientId
             }
         });
+
         return;
     }
+
     const s4: SelfServiceServicesService = req.app.get("backing-service");
     try {
         await s4.updateClient(
             req.params.serviceId,
             req.params.selfServiceClientId,
             req.params.clientId,
-            {data: clientName},
+            {client_name: newClientName},
             req.session.authenticationResult?.AccessToken as string
         );
     } catch (error) {
@@ -47,6 +50,7 @@ router.post("/change-client-name/:serviceId/:selfServiceClientId/:clientId", asy
         res.redirect("/there-is-a-problem");
         return;
     }
+
     req.session.updatedField = "client name";
     res.redirect(`/client-details/${req.params.serviceId}`);
 });
@@ -54,11 +58,11 @@ router.post("/change-client-name/:serviceId/:selfServiceClientId/:clientId", asy
 // Testing routes for Change your redirect URIs page
 router.get("/change-redirect-uris/:serviceId/:selfServiceClientId/:clientId", (req, res) => {
     res.render("service-details/change-redirect-uris.njk", {
+        serviceId: req.params.serviceId,
+        selfServiceClientId: req.params.selfServiceClientId,
+        clientId: req.params.clientId,
         values: {
-            redirectURIs: req.query?.redirectUris,
-            serviceId: req.params.serviceId,
-            selfServiceClientId: req.params.selfServiceClientId,
-            clientId: req.params.clientId
+            redirectURIs: req.query.redirectUris
         }
     });
 });
@@ -70,19 +74,14 @@ router.post(
         const redirectUris = req.body.redirectURIs.split(" ").filter((url: string) => url !== "");
         const s4: SelfServiceServicesService = req.app.get("backing-service");
 
-        try {
-            await s4.updateClient(
-                req.params.serviceId,
-                req.params.selfServiceClientId,
-                req.params.clientId,
-                {redirect_uris: redirectUris},
-                req.session.authenticationResult?.AccessToken as string
-            );
-        } catch (error) {
-            console.error(error);
-            res.redirect("/there-is-a-problem");
-            return;
-        }
+        await s4.updateClient(
+            req.params.serviceId,
+            req.params.selfServiceClientId,
+            req.params.clientId,
+            {redirect_uris: redirectUris},
+            req.session.authenticationResult?.AccessToken as string
+        );
+
         req.session.updatedField = "redirect URLs";
         res.redirect(`/client-details/${req.params.serviceId}`);
     }
@@ -90,7 +89,7 @@ router.post(
 
 // Testing routes for Change user attributes page
 router.get("/change-user-attributes/:serviceId/:selfServiceClientId/:clientId", (req, res) => {
-    const userAttributes = (req.query?.userAttributes as string).split(" ");
+    const userAttributes = (req.query.userAttributes as string).split(" ");
     const email: boolean = userAttributes.includes("email");
     const phone: boolean = userAttributes.includes("phone");
     const offline_access: boolean = userAttributes.includes("offline_access");
@@ -114,19 +113,15 @@ router.post("/change-user-attributes/:serviceId/:selfServiceClientId/:clientId",
     } else if (typeof req.body.userAttributes === "string") {
         attributes.push(req.body.userAttributes);
     }
-    try {
-        await s4.updateClient(
-            req.params.serviceId,
-            req.params.selfServiceClientId,
-            req.params.clientId,
-            {scopes: attributes},
-            req.session.authenticationResult?.AccessToken as string
-        );
-    } catch (error) {
-        console.error(error);
-        res.redirect("/there-is-a-problem");
-        return;
-    }
+
+    await s4.updateClient(
+        req.params.serviceId,
+        req.params.selfServiceClientId,
+        req.params.clientId,
+        {scopes: attributes},
+        req.session.authenticationResult?.AccessToken as string
+    );
+
     req.session.updatedField = "required user attributes";
     res.redirect(`/client-details/${req.params.serviceId}`);
 });
@@ -134,11 +129,11 @@ router.post("/change-user-attributes/:serviceId/:selfServiceClientId/:clientId",
 // Testing routes for Change your post logout redirect URIs page
 router.get("/change-post-logout-uris/:serviceId/:selfServiceClientId/:clientId", (req, res) => {
     res.render("service-details/change-post-logout-uris.njk", {
+        serviceId: req.params.serviceId,
+        selfServiceClientId: req.params.selfServiceClientId,
+        clientId: req.params.clientId,
         values: {
-            postLogoutURIs: req.query?.redirectUris, // this is not clientName
-            serviceId: req.params.serviceId,
-            selfServiceClientId: req.params.selfServiceClientId,
-            clientId: req.params.clientId
+            postLogoutURIs: req.query.redirectUris
         }
     });
 });
@@ -149,19 +144,15 @@ router.post(
     async (req, res) => {
         const postLogoutUris = req.body.postLogoutURIs.split(" ").filter((url: string) => url !== "");
         const s4: SelfServiceServicesService = req.app.get("backing-service");
-        try {
-            await s4.updateClient(
-                req.params.serviceId,
-                req.params.selfServiceClientId,
-                req.params.clientId,
-                {post_logout_redirect_uris: postLogoutUris},
-                req.session.authenticationResult?.AccessToken as string
-            );
-        } catch (error) {
-            console.error(error);
-            res.redirect("/there-is-a-problem");
-            return;
-        }
+
+        await s4.updateClient(
+            req.params.serviceId,
+            req.params.selfServiceClientId,
+            req.params.clientId,
+            {post_logout_redirect_uris: postLogoutUris},
+            req.session.authenticationResult?.AccessToken as string
+        );
+
         req.session.updatedField = "post-logout redirect URLs";
         res.redirect(`/client-details/${req.params.serviceId}`);
     }
@@ -170,7 +161,6 @@ router.post(
 // Testing routes for Change your public key page
 router.get("/change-public-key/:serviceId/:selfServiceClientId/:clientId", (req, res) => {
     res.render("service-details/change-public-key.njk", {
-        value: "", // this is not clientName
         serviceId: req.params.serviceId,
         selfServiceClientId: req.params.selfServiceClientId,
         clientId: req.params.clientId
@@ -178,21 +168,17 @@ router.get("/change-public-key/:serviceId/:selfServiceClientId/:clientId", (req,
 });
 
 router.post("/change-public-key/:serviceId/:selfServiceClientId/:clientId", convertPublicKeyForAuth, async (req, res) => {
-    const publicKey = req.body.authCompliantPublicKey as string;
+    const publicKey = req.body.serviceUserPublicKey as string;
     const s4: SelfServiceServicesService = req.app.get("backing-service");
-    try {
-        await s4.updateClient(
-            req.params.serviceId,
-            req.params.selfServiceClientId,
-            req.params.clientId,
-            {public_key: publicKey},
-            req.session.authenticationResult?.AccessToken as string
-        );
-    } catch (error) {
-        console.error(error);
-        res.redirect("/there-is-a-problem");
-        return;
-    }
+
+    await s4.updateClient(
+        req.params.serviceId,
+        req.params.selfServiceClientId,
+        req.params.clientId,
+        {public_key: publicKey},
+        req.session.authenticationResult?.AccessToken as string
+    );
+
     req.session.updatedField = "public key";
     res.redirect(`/client-details/${req.params.serviceId}`);
 });
@@ -232,7 +218,7 @@ router.get("/change-public-key-v2-returning", (req, res) => {
 });
 
 //// Testing post route to test error messages
-router.post("/change-public-key-v2/mockedServiceId/mockedSelfServiceClientId/mockedClientId", async (req, res) => {
+router.post("/change-public-key-v2", async (req, res) => {
     const serviceUserPublicKey = req.body.serviceUserPublicKey;
     const serviceUserPublicKeyText = req.body.serviceUserPublicKeyText;
     const serviceUserPublicKeyFile = req.body.serviceUserPublicKeyFile;
@@ -502,6 +488,7 @@ router.get("/wrong-email-code", (req, res) => {
         }
     });
 });
+
 // When implementing the backend, depending on journey we should request new code and after that redirect or render the appropriate template - depending on implementation
 router.post("/wrong-email-code", async (req, res) => {
     res.render("account/check-email.njk");

--- a/express/src/routes/testing-routes.ts
+++ b/express/src/routes/testing-routes.ts
@@ -323,60 +323,12 @@ router.get("/account-success-screen-test", (req, res) => {
     });
 });
 
-//// Testing route 'Form submitted' page for private beta
-router.get("/private-beta-form-submitted", (req, res) => {
-    res.render("service-details/private-beta-form-submitted.njk", {
-        serviceName: "My juggling service"
-    });
-});
-
-//// Testing routs Create 'Joining a private beta' page
-router.get("/private-beta", (req, res) => {
-    res.render("service-details/private-beta.njk", {
-        serviceName: req.query.serviceName,
-        emailAddress: req.session.emailAddress
-    });
-});
-
-router.post("/private-beta", async (req, res) => {
-    const yourName = req.body.yourName;
-    const department = req.body.department;
-    const emailAddress = req.body.emailAddress;
-    const serviceName = req.body.serviceName;
-    const errorMessages = new Map<string, string>();
-
-    if (yourName === "") {
-        errorMessages.set("yourName", "Enter your name");
-    }
-
-    if (department === "") {
-        errorMessages.set("department", "Enter your department");
-    }
-
-    if (errorMessages.size > 0) {
-        res.render("service-details/private-beta.njk", {
-            errorMessages: errorMessages,
-            values: {
-                yourName: yourName,
-                department: department
-            }
-        });
-
-        return;
-    }
-
-    const s4: SelfServiceServicesService = req.app.get("backing-service");
-    await s4.privateBetaRequest(yourName, department, serviceName, emailAddress, req.session.authenticationResult?.AccessToken as string);
-
-    res.redirect("/private-beta-form-submitted");
-});
-
 // Testing route for testing when the private beta request has already been submitted.
 router.get("/private-beta-submitted", (req, res) => {
     res.render("service-details/private-beta.njk", {
-        serviceName: "My juggling service",
         privateBetaRequestSubmitted: true,
-        dateRequestSubmitted: "10 May 2022"
+        dateRequestSubmitted: "10 May 2022",
+        serviceName: "My juggling license"
     });
 });
 

--- a/express/src/services/lambda-facade/LambdaFacade.ts
+++ b/express/src/services/lambda-facade/LambdaFacade.ts
@@ -1,9 +1,10 @@
-import axios, {Axios, AxiosResponse} from "axios";
-import {Service} from "../../../@types/Service";
-import LambdaFacadeInterface from "./LambdaFacadeInterface";
 import {AuthenticationResultType} from "@aws-sdk/client-cognito-identity-provider";
-import AuthenticationResultParser from "../../lib/AuthenticationResultParser";
+import {QueryCommandOutput} from "@aws-sdk/client-dynamodb";
+import axios, {Axios, AxiosResponse} from "axios";
 import {OnboardingTableItem} from "../../../@types/OnboardingTableItem";
+import {Service} from "../../../@types/Service";
+import AuthenticationResultParser from "../../lib/AuthenticationResultParser";
+import LambdaFacadeInterface from "./LambdaFacadeInterface";
 
 class LambdaFacade implements LambdaFacadeInterface {
     private instance: Axios;
@@ -72,17 +73,16 @@ class LambdaFacade implements LambdaFacadeInterface {
         clientId: string,
         updates: object,
         accessToken: string
-    ): Promise<AxiosResponse> {
-        // constrain type later
+    ): Promise<AxiosResponse<QueryCommandOutput>> {
+        // TODO constrain type later
         const body = {
             serviceId: serviceId,
             selfServiceClientId: selfServiceClientId,
             clientId: clientId,
             updates: updates
         };
-        return await (
-            await this.instance
-        ).post(`/Prod/do-update-client`, JSON.stringify(body), {
+
+        return this.instance.post(`/Prod/do-update-client`, JSON.stringify(body), {
             headers: {
                 "authorised-by": accessToken
             }
@@ -93,9 +93,10 @@ class LambdaFacade implements LambdaFacadeInterface {
         return await (await this.instance).get(`/Prod/get-services/${userId}`);
     }
 
-    async listClients(serviceId: string, accessToken: string): Promise<AxiosResponse> {
+    // TODO Don't we need to use the token to authorise when making the call to the database? Seems odd it's not used
+    listClients(serviceId: string, accessToken: string): Promise<AxiosResponse<QueryCommandOutput>> {
         const bareServiceId = serviceId.startsWith("service#") ? serviceId.substring(8) : serviceId;
-        return await (await this.instance).get(`/Prod/get-service-clients/${bareServiceId}`);
+        return this.instance.get(`/Prod/get-service-clients/${bareServiceId}`);
     }
 
     async updateUser(selfServiceUserId: string, updates: object, accessToken: string): Promise<AxiosResponse> {

--- a/express/src/services/lambda-facade/LambdaFacadeInterface.ts
+++ b/express/src/services/lambda-facade/LambdaFacadeInterface.ts
@@ -1,7 +1,8 @@
-import {AxiosResponse} from "axios";
-import {Service} from "../../../@types/Service";
 import {AuthenticationResultType} from "@aws-sdk/client-cognito-identity-provider";
+import {QueryCommandOutput} from "@aws-sdk/client-dynamodb";
+import {AxiosResponse} from "axios";
 import {OnboardingTableItem} from "../../../@types/OnboardingTableItem";
+import {Service} from "../../../@types/Service";
 
 export default interface LambdaFacadeInterface {
     putUser(user: OnboardingTableItem, accessToken: string): Promise<AxiosResponse>;
@@ -16,7 +17,8 @@ export default interface LambdaFacadeInterface {
 
     listServices(userId: string, accessToken: string): Promise<AxiosResponse>;
 
-    listClients(serviceId: string, accessToken: string): Promise<AxiosResponse>;
+    // TODO The QueryCommandOutput type should be replaced by a class shared between the frontend and the API (contract)
+    listClients(serviceId: string, accessToken: string): Promise<AxiosResponse<QueryCommandOutput>>;
 
     updateClient(
         serviceId: string,
@@ -24,7 +26,7 @@ export default interface LambdaFacadeInterface {
         clientId: string,
         updates: object,
         accessToken: string
-    ): Promise<AxiosResponse>;
+    ): Promise<AxiosResponse<QueryCommandOutput>>;
 
     privateBetaRequest(
         name: string,

--- a/express/src/services/lambda-facade/StubLambdaFacade.ts
+++ b/express/src/services/lambda-facade/StubLambdaFacade.ts
@@ -1,9 +1,10 @@
+import {AuthenticationResultType} from "@aws-sdk/client-cognito-identity-provider";
+import {QueryCommandOutput} from "@aws-sdk/client-dynamodb";
 import {AxiosResponse} from "axios";
+import {OnboardingTableItem} from "../../../@types/OnboardingTableItem";
 import {Service} from "../../../@types/Service";
 import {DynamoUser} from "../../../@types/user";
 import LambdaFacadeInterface from "./LambdaFacadeInterface";
-import {AuthenticationResultType} from "@aws-sdk/client-cognito-identity-provider";
-import {OnboardingTableItem} from "../../../@types/OnboardingTableItem";
 
 class StubLambdaFacade implements LambdaFacadeInterface {
     user: DynamoUser = {
@@ -80,14 +81,13 @@ class StubLambdaFacade implements LambdaFacadeInterface {
         } as AxiosResponse);
     }
 
-    listClients(serviceId: string, accessToken: string): Promise<AxiosResponse> {
+    listClients(serviceId: string, accessToken: string): Promise<AxiosResponse<QueryCommandOutput>> {
         return Promise.resolve({
             data: {
                 Items: [
                     {
-                        client_name: {S: this.serviceName},
-                        post_logoout_redirect_uris: {L: [{S: "http://localhost/"}, {S: "http://localhost/logged_out"}]},
-                        post_logout_redirect_uris: {L: [{S: "http://localhost/logged_out"}]},
+                        service_name: {S: this.serviceName},
+                        post_logout_redirect_uris: {L: [{S: "http://localhost/"}, {S: "http://localhost/logged_out"}]},
                         subject_type: {S: "pairwise"},
                         contacts: {L: [{S: "john.watts@digital.cabinet-office.gov.uk"}, {S: "onboarding@digital.cabinet-office.gov.uk"}]},
                         public_key: {

--- a/express/src/views/account/account.njk
+++ b/express/src/views/account/account.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
-{% set active = "your-account" %}
+{% set headerActiveItem = "your-account" %}
 {% set pageTitle = "Your account" %}
 {% set mainClasses = "account-summary" %}
 

--- a/express/src/views/account/change-email-address.njk
+++ b/express/src/views/account/change-email-address.njk
@@ -1,6 +1,6 @@
 {% extends "layout/form.njk" %}
 
-{% set active = "your-account" %}
+{% set headerActiveItem = "your-account" %}
 {% set pageTitle = "Change email address" %}
 {% set formAction = "/change-email-address" %}
 {% set formButtonText = "Confirm" %}

--- a/express/src/views/account/change-password.njk
+++ b/express/src/views/account/change-password.njk
@@ -1,6 +1,6 @@
 {% extends "layout/form.njk" %}
 
-{% set active = "your-account" %}
+{% set headerActiveItem = "your-account" %}
 {% set pageTitle = "Change password" %}
 {% set formAction = "/change-password" %}
 {% set formButtonText = "Confirm" %}

--- a/express/src/views/account/change-phone-number.njk
+++ b/express/src/views/account/change-phone-number.njk
@@ -1,6 +1,6 @@
 {% extends "layout/form.njk" %}
 
-{% set active = "your-account" %}
+{% set headerActiveItem = "your-account" %}
 {% set pageTitle = "Change phone number" %}
 {% set formAction = "/change-phone-number" %}
 {% set formButtonText = "Confirm" %}

--- a/express/src/views/account/change-service-name.njk
+++ b/express/src/views/account/change-service-name.njk
@@ -3,9 +3,8 @@
 
 {% set active = "your-account" %}
 {% set pageTitle = "Change service name" %}
-{% set formAction = "/change-service-name" %}
 {% set formButtonText = "Confirm" %}
-{% set formCancelUrl = "/client-details/" + values.selfServiceClientId %}
+{% set formCancelUrl = "/client-details/" + serviceId %}
 
 {% block beforeForm %}
   <h1 class="govuk-heading-l">Change your service name</h1>
@@ -15,10 +14,4 @@
 
 {% block formInputs %}
   {{ form.textInput("Service name", "serviceName") }}
-{% endblock %}
-
-{% block afterformInputs %}
-  {{ govukInput({ type: "hidden", value: values.selfServiceClientId, id: "selfServiceClientId", name: "selfServiceClientId" }) }}
-  {{ govukInput({ type: "hidden", value: values.clientId, id: "clientId", name: "clientId" }) }}
-  {{ govukInput({ type: "hidden", value: values.clientServiceId, id: "clientServiceId", name: "clientServiceId" }) }}
 {% endblock %}

--- a/express/src/views/account/change-service-name.njk
+++ b/express/src/views/account/change-service-name.njk
@@ -1,7 +1,7 @@
 {% extends "layout/form.njk" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% set active = "your-account" %}
+{% set headerActiveItem = "your-account" %}
 {% set pageTitle = "Change service name" %}
 {% set formButtonText = "Confirm" %}
 {% set formCancelUrl = "/client-details/" + serviceId %}

--- a/express/src/views/account/check-email.njk
+++ b/express/src/views/account/check-email.njk
@@ -1,7 +1,7 @@
 {% extends "layout/form.njk" %}
 {% from "macros/back-link.njk" import backLink %}
 
-{% set active = "your-account" %}
+{% set headerActiveItem = "your-account" %}
 {% set pageTitle = "Check your email address" %}
 {% set backLink = backLink("/change-email-address") %}
 {% set formAction = "/check-email-visual-test" %}

--- a/express/src/views/layout/base.njk
+++ b/express/src/views/layout/base.njk
@@ -49,30 +49,30 @@
             <ul id="navigation" class="govuk-header__navigation-list">
 
               {% if not isSignedIn %}
-                <li class="govuk-header__navigation-item{% if active == 'features' %} govuk-header__navigation-item--active{% endif %}">
+                <li class="govuk-header__navigation-item{% if headerActiveItem == "features" %} govuk-header__navigation-item--active{% endif %}">
                   <a class="govuk-header__link" href="https://www.sign-in.service.gov.uk/features">Features</a>
                 </li>
               {% endif %}
 
-              <li class="govuk-header__navigation-item{% if active == 'documentation' %} govuk-header__navigation-item--active{% endif %}">
+              <li class="govuk-header__navigation-item{% if headerActiveItem == "documentation" %} govuk-header__navigation-item--active{% endif %}">
                 <a class="govuk-header__link" href="https://www.sign-in.service.gov.uk/documentation">Documentation</a>
               </li>
-              <li class="govuk-header__navigation-item{% if active == 'support' %} govuk-header__navigation-item--active{% endif %}">
+              <li class="govuk-header__navigation-item{% if headerActiveItem == "support" %} govuk-header__navigation-item--active{% endif %}">
                 <a class="govuk-header__link" href="https://www.sign-in.service.gov.uk/support">Support</a>
               </li>
 
               {% if isSignedIn %}
-                <li class="govuk-header__navigation-item{% if active == 'your-account' %} govuk-header__navigation-item--active{% endif %}">
+                <li class="govuk-header__navigation-item{% if headerActiveItem == "your-account" %} govuk-header__navigation-item--active{% endif %}">
                   <a class="govuk-header__link" href="/account" id="your-account-top-nav">Your account</a>
                 </li>
                 <li class="govuk-header__navigation-item">
                   <a class="govuk-header__link" href="/account/sign-out">Sign out</a>
                 </li>
               {% else %}
-                <li class="govuk-header__navigation-item{% if active == 'get-started' %} govuk-header__navigation-item--active{% endif %}">
+                <li class="govuk-header__navigation-item{% if headerActiveItem == "get-started" %} govuk-header__navigation-item--active{% endif %}">
                   <a class="govuk-header__link" href="/">Get started</a>
                 </li>
-                <li class="govuk-header__navigation-item{% if active == 'sign-in' %} govuk-header__navigation-item--active{% endif %}">
+                <li class="govuk-header__navigation-item{% if headerActiveItem == "sign-in" %} govuk-header__navigation-item--active{% endif %}">
                   <a class="govuk-header__link" href="/sign-in">Sign in</a>
                 </li>
               {% endif %}

--- a/express/src/views/macros/form-inputs.njk
+++ b/express/src/views/macros/form-inputs.njk
@@ -1,5 +1,9 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 
 {% macro generate(action, buttonText, buttonClasses, cancelUrl) %}
   <form class="form" method="post"{% if action %} action="{{ action }}"{% endif %} novalidate="novalidate">
@@ -66,4 +70,79 @@
 
 {% macro urlInput(label, id) %}
   {{ textInput(label, id, "govuk-!-width-full", "Enter URIs starting with https://", "url", "url") }}
+{% endmacro %}
+
+{% macro hiddenInput(id, value) %}
+  {{ textInput(id = id, type = "hidden", value = value) }}
+{% endmacro %}
+
+{% macro textAreaInput(label, id, hint, rows = 5) %}
+  {{ govukTextarea({
+    label: {
+      text: label
+    } if label,
+    hint: {
+      text: hint
+    } if hint,
+    id: id,
+    name: id,
+    rows: rows,
+    value: values[id] if values and values.hasOwnProperty(id),
+    errorMessage: {
+      text: errorMessages[id]
+    } if errorMessages and errorMessages.hasOwnProperty(id)
+  }) }}
+{% endmacro %}
+
+{% macro checkboxesInput(label, id, items) %}
+  {{ govukCheckboxes({
+    fieldset: {
+      legend: {
+        text: label
+      }
+    } if label,
+    id: id,
+    name: id,
+    items: items
+  }) }}
+{% endmacro %}
+
+{% macro radiosInput(label, labelClasses, name, hint, items) %}
+  {{ govukRadios({
+    name: name,
+    idPrefix: name,
+    attributes: {
+      id: name + "-options"
+    },
+    fieldset: {
+      legend: {
+        text: label,
+        classes: labelClasses if labelClasses
+      }
+    },
+    hint: {
+      text: hint
+    } if hint,
+    value: values[id] if values and values.hasOwnProperty(id),
+    items: items,
+    errorMessage: {
+      text: errorMessages[id]
+    } if errorMessages and errorMessages.hasOwnProperty(id)
+  }) }}
+{% endmacro %}
+
+{% macro fileUploadInput(id, filetypes, label) %}
+  {{ govukFileUpload({
+    id: id,
+    name: id,
+    label: {
+      text: label
+    } if label,
+    attributes: {
+      accept: filetypes
+    } if filetypes,
+    errorMessage: {
+      text: errorMessages[id]
+    } if errorMessages and errorMessages.hasOwnProperty(id)
+  }) }}
 {% endmacro %}

--- a/express/src/views/manage-account/list-services.njk
+++ b/express/src/views/manage-account/list-services.njk
@@ -1,6 +1,6 @@
 {% extends './layout-manage-account.njk' %}
 
-{% set active = "your-account" %}
+{% set headerActiveItem = "your-account" %}
 {% set activeSidenavAccount = "your-services-sidenav" %}
 {% set pageTitle = "Your services" %}
 

--- a/express/src/views/no-account-found.njk
+++ b/express/src/views/no-account-found.njk
@@ -1,7 +1,7 @@
 {% extends "layout/base.njk" %}
 {% from "macros/back-link.njk" import backLink %}
 
-{% set active = "sign-in" %}
+{% set headerActiveItem = "sign-in" %}
 {% set pageTitle = "No account found" %}
 {% set backLink = backLink("/sign-in-password") %}
 

--- a/express/src/views/service-details/change-client-name.njk
+++ b/express/src/views/service-details/change-client-name.njk
@@ -3,10 +3,6 @@
 
 {% set pageTitle = "Change client name" %}
 
-{% set formAction %}
-  /change-client-name/{{ values.serviceId }}/{{ values.selfServiceClientId }}/{{ values.clientId }}
-{% endset %}
-
 {% block beforeForm %}
   <h1 class="govuk-heading-l govuk-!-margin-top-3">Change your client name</h1>
 

--- a/express/src/views/service-details/change-post-logout-uris.njk
+++ b/express/src/views/service-details/change-post-logout-uris.njk
@@ -2,10 +2,6 @@
 
 {% set pageTitle = "Change post logout redirect URIs" %}
 
-{% set formAction %}
-  /change-post-logout-uris/{{ values.serviceId }}/{{ values.selfServiceClientId }}/{{ values.clientId }}
-{% endset %}
-
 {% block beforeForm %}
   <h1 class="govuk-heading-l govuk-!-margin-top-3">Change your post logout redirect URIs</h1>
   <p class="govuk-body">Add the URI for the page you want your users to see after they sign out of your service.</p>

--- a/express/src/views/service-details/change-public-key-v2.njk
+++ b/express/src/views/service-details/change-public-key-v2.njk
@@ -1,15 +1,9 @@
-{% extends "./layout-service-details.njk" %}
-{% from "macros/error-summary.njk" import errorSummary %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
-{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+{% extends "./base-form-service-details.njk" %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% set pageTitle = "Change public key" %}
 
-{% block mainContent %}
-  {{ errorSummary(errorMessages) }}
-
+{% block beforeForm %}
   <h1 class="govuk-heading-l govuk-!-margin-top-3">Change your public key</h1>
 
   <p class="govuk-body">You need to
@@ -25,85 +19,32 @@
       <p class="govuk-body current-public-key-container">{{ currentPublicKey }}</p>
     {% endcall %}
   {% endif %}
+{% endblock %}
 
-  <form class="form" action="/change-public-key-v2/{{ serviceId }}/{{ selfServiceClientId }}/{{ clientId }}" method="post">
-    {% set textFieldHtml %}
-      {{ govukTextarea({
-        name: "serviceUserPublicKeyText",
-        id: "serviceUserPublicKeyText",
-        label: {
-          text: "Public key"
-        },
-        hint: {
-          text: "Paste in the entire public key in PEM format, including the headers"
-        },
-        value: value,
-        errorMessage: {
-          text: errorMessages.get('serviceUserPublicKeyText')
-        } if errorMessages and errorMessages.has('serviceUserPublicKeyText')
-      }) }}
-    {% endset -%}
+{% block formInputs %}
+  {% set textFieldHtml %}
+    {{ form.textAreaInput("Public key", "serviceUserPublicKeyText",
+      "Paste in the entire public key in PEM format, including the headers"
+    ) }}
+  {% endset %}
 
-    {% set fileUploadHtml %}
-      {{ govukFileUpload({
-        id: "serviceUserPublicKeyFile",
-        name: "serviceUserPublicKeyFile",
-        label: {
-          text: "Upload a file in .PEM format"
-        },
-        attributes: {
-          accept: ".pem"
-        },
-        errorMessage: {
-          text: errorMessages.get('serviceUserPublicKeyFile')
-        } if errorMessages and errorMessages.has('serviceUserPublicKeyFile')
-      }) }}
-    {% endset -%}
+  {% set fileUploadHtml %}
+    {{ form.fileUploadInput("serviceUserPublicKeyFile", ".pem", "Upload a file in .PEM format") }}
+  {% endset %}
 
-    {% if serviceUserPublicKey === 'text' %}
-      {% set textChecked = true %}
-    {% endif %}
-
-    {% if serviceUserPublicKey === 'file' %}
-      {% set fileChecked = true %}
-    {% endif %}
-
-    {{ govukRadios({
-      name: "serviceUserPublicKey",
-      id: "serviceUserPublicKey",
-      fieldset: {
-        legend: {
-          text: "Choose how to change your public key",
-          classes: "govuk-fieldset__legend--m"
+  {{ form.radiosInput("Choose how to change your public key", "govuk-fieldset__legend--m", "serviceUserPublicKey",
+    items = [
+      {
+        text: "Paste in your public key", value: "text", checked: serviceUserPublicKey == "text",
+        conditional: {
+          html: textFieldHtml
         }
       },
-      items: [
-        {
-          text: "Paste in your public key",
-          value: "text",
-          checked: textChecked,
-          conditional: {
-            html: textFieldHtml
-          }
-        },
-        {
-          text: "Upload your public key as a file",
-          value: "file",
-          checked: fileChecked,
-          conditional: {
-            html: fileUploadHtml
-          }
+      {
+        text: "Upload your public key as a file", value: "file", checked: serviceUserPublicKey == "file",
+        conditional: {
+          html: fileUploadHtml
         }
-      ],
-      errorMessage: {
-        text:  errorMessages.get('serviceUserPublicKey')
-      } if errorMessages and errorMessages.has('serviceUserPublicKey')
-    }) }}
-
-    <div class="govuk-button-group">
-      {{ govukButton({ text: "Confirm" }) }}
-      {# TODO When attached to backend to be replaced with : href="/client-details/{{serviceId}}" #}
-      <a class="govuk-link" href="/client-details-mocked">Cancel</a>
-    </div>
-  </form>
+      }
+    ]) }}
 {% endblock %}

--- a/express/src/views/service-details/change-public-key.njk
+++ b/express/src/views/service-details/change-public-key.njk
@@ -1,12 +1,8 @@
-{% extends "./layout-service-details.njk" %}
-{% from "macros/error-summary.njk" import errorSummary %}
-{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% extends "./base-form-service-details.njk" %}
 
 {% set pageTitle = "Change public key" %}
 
-{% block mainContent %}
-  {{ errorSummary(errorMessages) }}
-
+{% block beforeForm %}
   <h1 class="govuk-heading-l govuk-!-margin-top-3">Change your public key</h1>
 
   <p class="govuk-body">You need to
@@ -15,26 +11,10 @@
   </p>
 
   <h2 class="govuk-heading-m">Paste in your public key</h2>
+{% endblock %}
 
-  <form class="form" action="/change-public-key/{{ serviceId }}/{{ selfServiceClientId }}/{{ clientId }}" method="post">
-    {{ govukTextarea({
-      name: "serviceUserPublicKey",
-      id: "serviceUserPublicKey",
-      label: {
-        text: "Public key"
-      },
-      hint: {
-        text: "Paste in the entire public key in PEM format, including the headers"
-      },
-      value: value,
-      errorMessage: {
-        text:  errorMessages.get('serviceUserPublicKey')
-      } if  errorMessages else false
-    }) }}
-
-    <div class="govuk-button-group">
-      {{ govukButton({ text: "Confirm" }) }}
-      <a class="govuk-link" href="/client-details/{{ serviceId }}">Cancel</a>
-    </div>
-  </form>
+{% block formInputs %}
+  {{ form.textAreaInput("Public key", "serviceUserPublicKey",
+    "Paste in the entire public key in PEM format, including the headers"
+  ) }}
 {% endblock %}

--- a/express/src/views/service-details/change-redirect-uris.njk
+++ b/express/src/views/service-details/change-redirect-uris.njk
@@ -2,10 +2,6 @@
 
 {% set pageTitle = "Change redirect URIs" %}
 
-{% set formAction %}
-  /change-redirect-uris/{{ values.serviceId }}/{{  values.selfServiceClientId }}/{{  values.clientId }}
-{% endset %}
-
 {% block beforeForm %}
   <h1 class="govuk-heading-l govuk-!-margin-top-3">Change your redirect URIs</h1>
   <p class="govuk-body">Add the URI for the page you want your users to see after they sign in to your service.</p>

--- a/express/src/views/service-details/change-user-attributes.njk
+++ b/express/src/views/service-details/change-user-attributes.njk
@@ -1,9 +1,8 @@
-{% extends "./layout-service-details.njk" %}
-{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% extends "./base-form-service-details.njk" %}
 
 {% set pageTitle = "Change user attributes" %}
 
-{% block mainContent %}
+{% block beforeForm %}
   <h1 class="govuk-heading-l govuk-!-margin-top-3">Change the user attributes you get</h1>
 
   <p class="govuk-body">Select the
@@ -11,41 +10,17 @@
        class="govuk-link" target="_blank">user attributes (opens in new tab)</a> you would like your service to receive.
     These are also known as ‘scopes’ in the OpenID Connect (OIDC) specification.
   </p>
+{% endblock %}
 
-  <form class="form" action="/change-user-attributes/{{ serviceId }}/{{ selfServiceClientId }}/{{ clientId }}" method="post">
-    {{ govukCheckboxes({
-      name: "userAttributes",
-      id: "userAttributes",
-      fieldset: {
-        legend: {
-          text: "User attributes"
-        }
-      },
-      items: [
-        {
-          value: "email",
-          text: "Email address",
-          checked: email
-        },
-        {
-          value: "phone",
-          text: "Phone number",
-          checked: phone
-        },
-        {
-          value: "offline_access",
-          text: "Offline access",
-          hint: {
-            html: "This gives you a refresh token so you can access the <code>/userinfo</code> endpoint for longer than 3 minutes"
-          },
-          checked: offline_access
-        }
-      ]
-    }) }}
-
-    <div class="govuk-button-group">
-      {{ govukButton({ text: "Confirm" }) }}
-      <a class="govuk-link" href="/client-details/{{ serviceId }}">Cancel</a>
-    </div>
-  </form>
+{% block formInputs %}
+  {{ form.checkboxesInput("User attributes", "userAttributes", [
+    {text: "Email address", value: "email", checked: email},
+    {text: "Phone number", value: "phone", checked: phone},
+    {
+      text: "Offline access", value: "offline_access", checked: offline_access,
+      hint: {
+        html: "This gives you a refresh token so you can access the <code>/userinfo</code> endpoint for longer than 3 minutes"
+      }
+    }
+  ]) }}
 {% endblock %}

--- a/express/src/views/service-details/layout-service-details.njk
+++ b/express/src/views/service-details/layout-service-details.njk
@@ -8,11 +8,16 @@
     <div class="govuk-breadcrumbs">
       <ol class="govuk-breadcrumbs__list navigation-service-change-list">
         <li class="govuk-breadcrumbs__list-item govuk-!-font-size-19">
-          <a class="govuk-breadcrumbs__link" href="#">Your services</a>
+          <a class="govuk-breadcrumbs__link" href="/account/list-services">Your services</a>
         </li>
-        <li class="govuk-breadcrumbs__list-item govuk-!-font-size-19 govuk-!-font-weight-bold">{{ serviceName }}</li>
+        {% if serviceName %}
+          <li class="govuk-breadcrumbs__list-item govuk-!-font-size-19 govuk-!-font-weight-bold">{{ serviceName }}</li>
+        {% endif %}
       </ol>
-      <a href="/change-service-name/{{ serviceName }}/{{ selfServiceClientId }}/{{ authClientId }}/{{ clientServiceId }}" class="govuk-link govuk-link--no-visited-state navigation-service-change govuk-!-font-size-19">Change service name</a>
+      <a href="/change-service-name/{{ serviceId }}/{{ selfServiceClientId }}/{{ clientId }}?serviceName={{ serviceName }}"
+         class="govuk-link govuk-link--no-visited-state navigation-service-change govuk-!-font-size-19">
+        Change service name
+      </a>
     </div>
   </div>
 {% endblock %}

--- a/express/src/views/service-details/layout-service-details.njk
+++ b/express/src/views/service-details/layout-service-details.njk
@@ -1,6 +1,7 @@
 {% extends "layout/base.njk" %}
 
-{% set active = active | default("client-details") %}
+{% set headerActiveItem = "your-account" %}
+{% set sidebarActiveItem = sidebarActiveItem | default("client-details") %}
 {% set mainClasses = "govuk-!-padding-top-5 left-nav-wrapper" %}
 
 {% block beforeContent %}
@@ -27,10 +28,10 @@
     <div class="govuk-grid-column-one-third">
       <nav class="side-navigation govuk-!-margin-top-3">
         <ul class="govuk-list side-navigation__list">
-          <li class="side-navigation__item{% if active == 'client-details' %} side-navigation__item--active{% endif %}">
+          <li class="side-navigation__item{% if sidebarActiveItem == 'client-details' %} side-navigation__item--active{% endif %}">
             <a class="govuk-link govuk-link--no-visited-state" href="/client-details/{{ serviceId }}">Client details</a>
           </li>
-          <li class="side-navigation__item{% if active == 'private-beta' %} side-navigation__item--active{% endif %}">
+          <li class="side-navigation__item{% if sidebarActiveItem == 'private-beta' %} side-navigation__item--active{% endif %}">
             <a class="govuk-link govuk-link--no-visited-state" href="/private-beta/{{ serviceId }}/{{ selfServiceClientId }}/{{ clientId }}">
               Joining private beta
             </a>

--- a/express/src/views/service-details/layout-service-details.njk
+++ b/express/src/views/service-details/layout-service-details.njk
@@ -28,12 +28,12 @@
       <nav class="side-navigation govuk-!-margin-top-3">
         <ul class="govuk-list side-navigation__list">
           <li class="side-navigation__item{% if active == 'client-details' %} side-navigation__item--active{% endif %}">
-            {# TODO When attached to backend to be replaced with : href="/client-details/{{serviceId}}" #}
-            <a class="govuk-link govuk-link--no-visited-state" href="/client-details-mocked">Client details</a>
-            {# <a class="govuk-link govuk-link--no-visited-state" href="/client-details/{{ serviceId }}">Client details</a> #}
+            <a class="govuk-link govuk-link--no-visited-state" href="/client-details/{{ serviceId }}">Client details</a>
           </li>
           <li class="side-navigation__item{% if active == 'private-beta' %} side-navigation__item--active{% endif %}">
-            <a class="govuk-link govuk-link--no-visited-state" href="/private-beta?serviceName={{ serviceName }}">Joining private beta</a>
+            <a class="govuk-link govuk-link--no-visited-state" href="/private-beta/{{ serviceId }}/{{ selfServiceClientId }}/{{ clientId }}">
+              Joining private beta
+            </a>
           </li>
         </ul>
       </nav>

--- a/express/src/views/service-details/private-beta-form-submitted.njk
+++ b/express/src/views/service-details/private-beta-form-submitted.njk
@@ -1,7 +1,7 @@
 {% extends "./layout-service-details.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
-{% set active = "private-beta" %}
+{% set sidebarActiveItem = "private-beta" %}
 {% set pageTitle = "Private beta form submitted" %}
 
 {% block mainContent %}

--- a/express/src/views/service-details/private-beta.njk
+++ b/express/src/views/service-details/private-beta.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% set active = "private-beta" %}
+{% set sidebarActiveItem = "private-beta" %}
 {% set pageTitle = "Joining private beta" %}
 {% set formButtonText = "Submit" %}
 {% set formCancelUrl = "" %}

--- a/express/src/views/service-details/private-beta.njk
+++ b/express/src/views/service-details/private-beta.njk
@@ -1,14 +1,14 @@
-{% extends "./layout-service-details.njk" %}
-{% from "macros/error-summary.njk" import errorSummary %}
+{% extends "./base-form-service-details.njk" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% set active = "private-beta" %}
 {% set pageTitle = "Joining private beta" %}
+{% set formButtonText = "Submit" %}
+{% set formCancelUrl = "" %}
+{% set hideForm = true if privateBetaRequestSubmitted %}
 
-{% block mainContent %}
-  {{ errorSummary(errorMessages) }}
-
+{% block beforeForm %}
   <h1 class="govuk-heading-l govuk-!-margin-top-3">Joining private beta</h1>
 
   <p class="govuk-body">If you want to go live with GOV.UK Sign In and offer it to your users, you need to join our private beta.</p>
@@ -27,53 +27,30 @@
     <div class="govuk-inset-text">
       You submitted your details on {{ dateRequestSubmitted }}.
     </div>
-  {% else %}
-    <form class="form" action="/private-beta" method="post">
-      {{ govukInput({
-        label: {
-          text: "Your name"
-        },
-        name: "yourName",
-        id: "yourName",
-        classes: "govuk-!-width-full",
-        value: value.yourName,
-        errorMessage: {
-          text: errorMessages.get('yourName')
-        } if errorMessages and errorMessages.has('yourName')
-      }) }}
-
-      {{ govukInput({
-        label: {
-          text: "Department"
-        },
-        name: "department",
-        id: "department",
-        classes: "govuk-!-width-full",
-        value: value.department,
-        errorMessage: {
-          text: errorMessages.get('department')
-        } if errorMessages and errorMessages.has('department')
-      }) }}
-
-      <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-2">Information we already have</p>
-
-      {{ govukSummaryList({
-        rows: [
-          {
-            key: {text: "Email address"},
-            value: {text: emailAddress}
-          },
-          {
-            key: {text: "Service name"},
-            value: {text: serviceName}
-          }
-        ]
-      }) }}
-
-      {{ govukInput({ type: "hidden", value: serviceName, id: "serviceName", name: "serviceName" }) }}
-      {{ govukInput({ type: "hidden", value: emailAddress, id: "emailAddress", name: "emailAddress" }) }}
-
-      {{ govukButton({ text: "Submit" }) }}
-    </form>
   {% endif %}
 {% endblock %}
+
+{% if not privateBetaRequestSubmitted %}
+  {% block formInputs %}
+    {{ form.textInput("Your name", "yourName") }}
+    {{ form.textInput("Department", "department") }}
+    {{ form.hiddenInput("serviceName", serviceName) }}
+  {% endblock %}
+
+  {% block afterformInputs %}
+    <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-2">Information we already have</p>
+
+    {{ govukSummaryList({
+      rows: [
+        {
+          key: {text: "Email address"},
+          value: {text: emailAddress}
+        },
+        {
+          key: {text: "Service name"},
+          value: {text: serviceName}
+        }
+      ]
+    }) }}
+  {% endblock %}
+{% endif %}

--- a/express/src/views/sign-in-enter-password.njk
+++ b/express/src/views/sign-in-enter-password.njk
@@ -1,7 +1,7 @@
 {% extends "layout/form.njk" %}
 {% from "macros/back-link.njk" import backLink %}
 
-{% set active = "sign-in" %}
+{% set headerActiveItem = "sign-in" %}
 {% set backLink = backLink("/sign-in") %}
 {% set pageTitle = "Enter your password" %}
 {% set formAction = "/sign-in-password" %}

--- a/express/src/views/sign-in.njk
+++ b/express/src/views/sign-in.njk
@@ -1,6 +1,6 @@
 {% extends "layout/form.njk" %}
 
-{% set active = "sign-in" %}
+{% set headerActiveItem = "sign-in" %}
 {% set pageTitle = "Sign in to your GOV.UK Sign In admin account" %}
 {% set formAction = "/sign-in" %}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
         "backend/dynamo-api"
       ],
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "^3.213.0"
+        "@aws-sdk/client-cognito-identity": "^3.213.0",
+        "@aws-sdk/client-dynamodb": "^3.160.0"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.36.0",
@@ -27,7 +28,6 @@
     "backend/dynamo-api": {
       "name": "gds-di-onboarding-dynamo-api",
       "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.160.0",
         "@aws-sdk/client-lambda": "^3.160.0",
         "@aws-sdk/client-sfn": "^3.160.0",
         "@aws-sdk/client-sns": "^3.162.0",
@@ -1028,6 +1028,36 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.201.0.tgz",
+      "integrity": "sha512-F3JlXo5GusbeZR956hA9VxmDxUeg77Xh6o8fveAE2+G4Bjcb1iq9jPNlw6A14vDj3oTKenv2LLnjL2OIfl6hRA==",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.201.0",
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/signature-v4": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/url-parser": "3.201.0",
+        "@aws-sdk/util-config-provider": "3.201.0",
+        "@aws-sdk/util-middleware": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.201.0.tgz",
+      "integrity": "sha512-EbXtjhdHfyEgDHrfduEmukMLls0cEamJ5VlUX5u1gPXHuT7Ju78+t6ig3BnMnmhaePIO5voNC+gZU5J29g+6cg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/tslib": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -1769,6 +1799,36 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.201.0.tgz",
+      "integrity": "sha512-F3JlXo5GusbeZR956hA9VxmDxUeg77Xh6o8fveAE2+G4Bjcb1iq9jPNlw6A14vDj3oTKenv2LLnjL2OIfl6hRA==",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.201.0",
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/signature-v4": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/url-parser": "3.201.0",
+        "@aws-sdk/util-config-provider": "3.201.0",
+        "@aws-sdk/util-middleware": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.201.0.tgz",
+      "integrity": "sha512-EbXtjhdHfyEgDHrfduEmukMLls0cEamJ5VlUX5u1gPXHuT7Ju78+t6ig3BnMnmhaePIO5voNC+gZU5J29g+6cg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-sso/node_modules/tslib": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -1815,6 +1875,36 @@
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.201.0",
         "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.201.0.tgz",
+      "integrity": "sha512-F3JlXo5GusbeZR956hA9VxmDxUeg77Xh6o8fveAE2+G4Bjcb1iq9jPNlw6A14vDj3oTKenv2LLnjL2OIfl6hRA==",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.201.0",
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/signature-v4": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/url-parser": "3.201.0",
+        "@aws-sdk/util-config-provider": "3.201.0",
+        "@aws-sdk/util-middleware": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.201.0.tgz",
+      "integrity": "sha512-EbXtjhdHfyEgDHrfduEmukMLls0cEamJ5VlUX5u1gPXHuT7Ju78+t6ig3BnMnmhaePIO5voNC+gZU5J29g+6cg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.201.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -12868,6 +12958,30 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
+        "@aws-sdk/middleware-endpoint": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.201.0.tgz",
+          "integrity": "sha512-F3JlXo5GusbeZR956hA9VxmDxUeg77Xh6o8fveAE2+G4Bjcb1iq9jPNlw6A14vDj3oTKenv2LLnjL2OIfl6hRA==",
+          "requires": {
+            "@aws-sdk/middleware-serde": "3.201.0",
+            "@aws-sdk/protocol-http": "3.201.0",
+            "@aws-sdk/signature-v4": "3.201.0",
+            "@aws-sdk/types": "3.201.0",
+            "@aws-sdk/url-parser": "3.201.0",
+            "@aws-sdk/util-config-provider": "3.201.0",
+            "@aws-sdk/util-middleware": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.201.0.tgz",
+          "integrity": "sha512-EbXtjhdHfyEgDHrfduEmukMLls0cEamJ5VlUX5u1gPXHuT7Ju78+t6ig3BnMnmhaePIO5voNC+gZU5J29g+6cg==",
+          "requires": {
+            "@aws-sdk/types": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
         "tslib": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -13067,6 +13181,30 @@
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/middleware-endpoint": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.201.0.tgz",
+          "integrity": "sha512-F3JlXo5GusbeZR956hA9VxmDxUeg77Xh6o8fveAE2+G4Bjcb1iq9jPNlw6A14vDj3oTKenv2LLnjL2OIfl6hRA==",
+          "requires": {
+            "@aws-sdk/middleware-serde": "3.201.0",
+            "@aws-sdk/protocol-http": "3.201.0",
+            "@aws-sdk/signature-v4": "3.201.0",
+            "@aws-sdk/types": "3.201.0",
+            "@aws-sdk/url-parser": "3.201.0",
+            "@aws-sdk/util-config-provider": "3.201.0",
+            "@aws-sdk/util-middleware": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.201.0.tgz",
+          "integrity": "sha512-EbXtjhdHfyEgDHrfduEmukMLls0cEamJ5VlUX5u1gPXHuT7Ju78+t6ig3BnMnmhaePIO5voNC+gZU5J29g+6cg==",
+          "requires": {
+            "@aws-sdk/types": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
         "tslib": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -13545,6 +13683,30 @@
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/middleware-endpoint": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.201.0.tgz",
+          "integrity": "sha512-F3JlXo5GusbeZR956hA9VxmDxUeg77Xh6o8fveAE2+G4Bjcb1iq9jPNlw6A14vDj3oTKenv2LLnjL2OIfl6hRA==",
+          "requires": {
+            "@aws-sdk/middleware-serde": "3.201.0",
+            "@aws-sdk/protocol-http": "3.201.0",
+            "@aws-sdk/signature-v4": "3.201.0",
+            "@aws-sdk/types": "3.201.0",
+            "@aws-sdk/url-parser": "3.201.0",
+            "@aws-sdk/util-config-provider": "3.201.0",
+            "@aws-sdk/util-middleware": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.201.0.tgz",
+          "integrity": "sha512-EbXtjhdHfyEgDHrfduEmukMLls0cEamJ5VlUX5u1gPXHuT7Ju78+t6ig3BnMnmhaePIO5voNC+gZU5J29g+6cg==",
+          "requires": {
+            "@aws-sdk/types": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
         "tslib": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -18097,7 +18259,6 @@
     "gds-di-onboarding-dynamo-api": {
       "version": "file:backend/dynamo-api",
       "requires": {
-        "@aws-sdk/client-dynamodb": "^3.160.0",
         "@aws-sdk/client-lambda": "^3.160.0",
         "@aws-sdk/client-sfn": "^3.160.0",
         "@aws-sdk/client-sns": "^3.162.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "typescript": "^4.8.2"
   },
   "dependencies": {
-    "@aws-sdk/client-cognito-identity": "^3.213.0"
+    "@aws-sdk/client-cognito-identity": "^3.213.0",
+    "@aws-sdk/client-dynamodb": "^3.160.0"
   }
 }


### PR DESCRIPTION
**Implement the manage account/client details routes and render the pages with correct parameters**

- Make sure all links work and pass the necessary values to render all the views

- Bring the join private beta routes to the manage account controller from test routes

- Add a return type for the lambdas calling the database API. For now, we're using the AWS SKD types but in the future we should switch to using our own types shared by the API and the frontend (the 'contract)'

  Temporarily Move the `@aws-sdk/client-dynamodb` package to the main `package.json` file as it's now used in multiple projects.

- Don't specify form action path for the forms - they can post to the URLs they're rendered at and we don't need to pass the params as hidden inputs as they are available on the receiving end from URL params on POST

- Check the user is signed in for all manage account routes

- Add new form input types: hidden input, text area, checkboxes, radios and file upload

 **Correctly highlight header and sidebar navigation items** 

Use different names to distinguish the two so on the service details page we can highlight an item in the header as well as in the sidebar.