### PR TITLE
SSE-2398 Make Post Logout URLs optional

### DIFF
--- a/backend/dynamo-api/package.json
+++ b/backend/dynamo-api/package.json
@@ -8,6 +8,7 @@
     "test": "jest --silent"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.241.0",
     "@aws-sdk/client-lambda": "^3.160.0",
     "@aws-sdk/client-sfn": "^3.160.0",
     "@aws-sdk/client-sns": "^3.162.0",
@@ -17,8 +18,8 @@
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.102",
-    "@types/node": "^18.7.14",
     "@types/jest": "^29.0.0",
+    "@types/node": "^18.7.14",
     "esbuild": "^0.15.6"
   }
 }

--- a/backend/dynamo-api/src/handlers/put-service-client.ts
+++ b/backend/dynamo-api/src/handlers/put-service-client.ts
@@ -1,39 +1,39 @@
-import {APIGatewayProxyEvent, APIGatewayProxyResult} from 'aws-lambda';
+import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import DynamoClient from "../client/DynamoClient";
 import {randomUUID} from "crypto";
+import {OnboardingTableItem} from "../@Types/OnboardingTableItem";
 
 const client = new DynamoClient();
 
 export const putServiceClientHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
     const payload = JSON.parse(event.body as string);
 
-    let record = {
+    const record: OnboardingTableItem = {
         pk: payload.service.id,
         sk: `client#${randomUUID()}`,
         clientId: payload.client_id,
-        type: 'integration',
+        type: "integration",
         public_key: payload.public_key,
         redirect_uris: payload.redirect_uris,
         contacts: payload.contacts,
         scopes: payload.scopes,
-        post_logout_redirect_uris: payload.post_logout_redirect_uris,
         subject_type: payload.subject_type,
         service_type: payload.service_type,
-        client_name: 'integration',
+        client_name: "integration",
         service_name: payload.service.serviceName,
-        default_fields: ['data', 'public_key', 'redirect_uris', 'scopes', 'post_logout_redirect_uris', 'subject_type', 'service_type']
+        default_fields: ["data", "public_key", "redirect_uris", "scopes", "post_logout_redirect_uris", "subject_type", "service_type"]
     };
 
-    let response = {statusCode: 200, body: JSON.stringify("OK")};
+    const response = {statusCode: 200, body: JSON.stringify("OK")};
     await client
         .put(record)
-        .then((putItemOutput) => {
+        .then(putItemOutput => {
             response.statusCode = 200;
-            response.body = JSON.stringify(record)
+            response.body = JSON.stringify(record);
         })
-        .catch((putItemOutput) => {
+        .catch(putItemOutput => {
             response.statusCode = 500;
-            response.body = JSON.stringify(putItemOutput)
+            response.body = JSON.stringify(putItemOutput);
         });
 
     return response;

--- a/backend/dynamo-api/src/handlers/register-client.ts
+++ b/backend/dynamo-api/src/handlers/register-client.ts
@@ -1,9 +1,7 @@
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
-import axios, { Axios } from "axios"; // TODO: Until Onboarding takes over client registry / just for now
+import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
+import axios, {Axios} from "axios"; // TODO: Until Onboarding takes over client registry / just for now
 
-let instance: Axios;
-
-instance = axios.create({
+const instance: Axios = axios.create({
     baseURL: process.env.AUTH_REGISTRATION_BASE_URL,
     headers: {
         "Content-Type": "application/json"
@@ -11,27 +9,26 @@ instance = axios.create({
 });
 
 export const registerClientHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-    let payload: any = event;
+    const payload: any = event;
 
-    const public_key = 'MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAp2mLkQGo24Kz1rut0oZlviMkGomlQCH+iT1pFvegZFXq39NPjRWyatmXp/XIUPqCq9Kk8/+tq4Sgjw+EM5tATJ06j5r+35of58ATGVPniW//IhGizrv6/ebGcGEUJ0Y/ZmlCHYPV+lbewpttQ/IYKM1nr3k/Rl6qepbVYe+MpGubluQvdhgUYel9OzxiOvUk7XI0axPquiXzoEgmNNOai8+WhYTkBqE3/OucAv+XwXdnx4XHmKzMwTv93dYMpUmvTxWcSeEJ/4/SrbiK4PyHWVKU2BozfSUejVNhahAzZeyyDwhYJmhBaZi/3eOOlqGXj9UdkOXbl3vcwBH8wD30O9/4F5ERLKxzOaMnKZ+RpnygWF0qFhf+UeFMy+O06sdgiaFnXaSCsIy/SohspkKiLjNnhvrDNmPLMQbQKQlJdcp6zUzI7Gzys7luEmOxyMpA32lDBQcjL7KNwM15s4ytfrJ46XEPZUXESce2gj6NazcPPsrTa/Q2+oLS9GWupGh7AgMBAAE=';
-    const redirect_uris = ['http://localhost/'];
-    const scopes = ['openid', 'email', 'phone'];
-    const post_logout_redirect_uris = ['http://localhost/'];
-    const subject_type = 'pairwise';
-    const service_type = 'MANDATORY';
-    const sector_identifier_uri = 'http://localhost/';
+    const public_key =
+        "MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAp2mLkQGo24Kz1rut0oZlviMkGomlQCH+iT1pFvegZFXq39NPjRWyatmXp/XIUPqCq9Kk8/+tq4Sgjw+EM5tATJ06j5r+35of58ATGVPniW//IhGizrv6/ebGcGEUJ0Y/ZmlCHYPV+lbewpttQ/IYKM1nr3k/Rl6qepbVYe+MpGubluQvdhgUYel9OzxiOvUk7XI0axPquiXzoEgmNNOai8+WhYTkBqE3/OucAv+XwXdnx4XHmKzMwTv93dYMpUmvTxWcSeEJ/4/SrbiK4PyHWVKU2BozfSUejVNhahAzZeyyDwhYJmhBaZi/3eOOlqGXj9UdkOXbl3vcwBH8wD30O9/4F5ERLKxzOaMnKZ+RpnygWF0qFhf+UeFMy+O06sdgiaFnXaSCsIy/SohspkKiLjNnhvrDNmPLMQbQKQlJdcp6zUzI7Gzys7luEmOxyMpA32lDBQcjL7KNwM15s4ytfrJ46XEPZUXESce2gj6NazcPPsrTa/Q2+oLS9GWupGh7AgMBAAE=";
+    const redirect_uris = ["http://localhost/"];
+    const scopes = ["openid", "email", "phone"];
+    const subject_type = "pairwise";
+    const service_type = "MANDATORY";
+    const sector_identifier_uri = "http://localhost/";
 
-    let clientConfig = {
+    const clientConfig = {
         client_name: payload.service.serviceName,
         public_key: public_key,
         redirect_uris: redirect_uris,
         contacts: [payload.contactEmail, "onboarding@digital.cabinet-office.gov.uk"], // TODO - remove second email before prod
         scopes: scopes,
-        post_logout_redirect_uris: post_logout_redirect_uris,
         subject_type: subject_type,
         service_type: service_type,
         sector_identifier_uri: sector_identifier_uri
-    }
+    };
 
     const result = await (await instance).post("/connect/register", JSON.stringify(clientConfig));
     const body = {...clientConfig, ...result.data, ...payload};
@@ -40,4 +37,4 @@ export const registerClientHandler = async (event: APIGatewayProxyEvent): Promis
         statusCode: 200,
         body: JSON.stringify(body)
     };
-}
+};

--- a/backend/dynamo-api/template.yaml
+++ b/backend/dynamo-api/template.yaml
@@ -438,11 +438,11 @@ Resources:
           {
             Effect: Allow,
             Action: [
-              "states:StartSyncExecution"
+                "states:StartSyncExecution"
             ],
             Resource: {
               Fn::Sub: [
-                "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${stateMachineName}",
+                  "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${stateMachineName}",
                 {
                   stateMachineName: {
                     Fn::GetAtt: [NewServiceStepFunction, Name]
@@ -527,11 +527,11 @@ Resources:
           {
             Effect: Allow,
             Action: [
-              "states:StartSyncExecution"
+                "states:StartSyncExecution"
             ],
             Resource: {
               Fn::Sub: [
-                "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${stateMachineName}",
+                  "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${stateMachineName}",
                 {
                   stateMachineName: {
                     Fn::GetAtt: [NewClientStepFunction, Name]
@@ -580,11 +580,11 @@ Resources:
           {
             Effect: Allow,
             Action: [
-              "states:StartSyncExecution"
+                "states:StartSyncExecution"
             ],
             Resource: {
               Fn::Sub: [
-                "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${stateMachineName}",
+                  "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${stateMachineName}",
                 {
                   stateMachineName: {
                     Fn::GetAtt: [UpdateClientStepFunction, Name]

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
     "backend/dynamo-api": {
       "name": "gds-di-onboarding-dynamo-api",
       "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.241.0",
         "@aws-sdk/client-lambda": "^3.160.0",
         "@aws-sdk/client-sfn": "^3.160.0",
         "@aws-sdk/client-sns": "^3.162.0",
@@ -980,47 +981,47 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.201.0.tgz",
-      "integrity": "sha512-RyZmvjhd99FgBnMLy5yirJCwiHGyCfHmZq332SUNL6nyWVbEUBAIi7/xiE4OPwScMpbE1iilJYCxcWey2gZdIw==",
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.241.0.tgz",
+      "integrity": "sha512-UFbX6KXHy18liDcFbKu/HUQdxDeAeGjl/HBFQ6tXq4eRx0tfMSsBZYNDJZl2T+bUpbBIi1Qzc7cH/g3FOO1vQQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.201.0",
-        "@aws-sdk/config-resolver": "3.201.0",
-        "@aws-sdk/credential-provider-node": "3.201.0",
-        "@aws-sdk/fetch-http-handler": "3.201.0",
-        "@aws-sdk/hash-node": "3.201.0",
-        "@aws-sdk/invalid-dependency": "3.201.0",
-        "@aws-sdk/middleware-content-length": "3.201.0",
-        "@aws-sdk/middleware-endpoint": "3.201.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.201.0",
-        "@aws-sdk/middleware-host-header": "3.201.0",
-        "@aws-sdk/middleware-logger": "3.201.0",
-        "@aws-sdk/middleware-recursion-detection": "3.201.0",
-        "@aws-sdk/middleware-retry": "3.201.0",
-        "@aws-sdk/middleware-serde": "3.201.0",
-        "@aws-sdk/middleware-signing": "3.201.0",
-        "@aws-sdk/middleware-stack": "3.201.0",
-        "@aws-sdk/middleware-user-agent": "3.201.0",
-        "@aws-sdk/node-config-provider": "3.201.0",
-        "@aws-sdk/node-http-handler": "3.201.0",
-        "@aws-sdk/protocol-http": "3.201.0",
-        "@aws-sdk/smithy-client": "3.201.0",
-        "@aws-sdk/types": "3.201.0",
-        "@aws-sdk/url-parser": "3.201.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "@aws-sdk/util-base64-node": "3.201.0",
+        "@aws-sdk/client-sts": "3.241.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.241.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.234.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.201.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.201.0",
-        "@aws-sdk/util-defaults-mode-node": "3.201.0",
-        "@aws-sdk/util-endpoints": "3.201.0",
-        "@aws-sdk/util-user-agent-browser": "3.201.0",
-        "@aws-sdk/util-user-agent-node": "3.201.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.241.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.201.0",
-        "@aws-sdk/util-waiter": "3.201.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/util-waiter": "3.226.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
@@ -1028,30 +1029,764 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.201.0.tgz",
-      "integrity": "sha512-F3JlXo5GusbeZR956hA9VxmDxUeg77Xh6o8fveAE2+G4Bjcb1iq9jPNlw6A14vDj3oTKenv2LLnjL2OIfl6hRA==",
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
+      "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
       "dependencies": {
-        "@aws-sdk/middleware-serde": "3.201.0",
-        "@aws-sdk/protocol-http": "3.201.0",
-        "@aws-sdk/signature-v4": "3.201.0",
-        "@aws-sdk/types": "3.201.0",
-        "@aws-sdk/url-parser": "3.201.0",
-        "@aws-sdk/util-config-provider": "3.201.0",
-        "@aws-sdk/util-middleware": "3.201.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.201.0.tgz",
-      "integrity": "sha512-EbXtjhdHfyEgDHrfduEmukMLls0cEamJ5VlUX5u1gPXHuT7Ju78+t6ig3BnMnmhaePIO5voNC+gZU5J29g+6cg==",
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
+      "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
       "dependencies": {
-        "@aws-sdk/types": "3.201.0",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.241.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
+      "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.241.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sts": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
+      "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.241.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-sdk-sts": "3.226.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.241.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+      "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
+      "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
+      "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
+      "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.241.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
+      "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-ini": "3.241.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.241.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
+      "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
+      "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.241.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/token-providers": "3.241.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
+      "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
+      "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/hash-node": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
+      "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
+      "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
+      "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
+      "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
+      "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
+      "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
+      "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
+      "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
+      "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
+      "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
+      "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
+      "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
+      "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
+      "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
+      "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/property-provider": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+      "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+      "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+      "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+      "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+      "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
+      "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/token-providers": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
+      "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.241.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/types": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/url-parser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+      "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
+      "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
+      "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
+      "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+      "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
+      "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
+      "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-waiter": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
+      "integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -2080,9 +2815,9 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@aws-sdk/endpoint-cache": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.201.0.tgz",
-      "integrity": "sha512-QgT4Wm19yQ/HbvxNeYaR7m9uEYhW+0YY9nSpnRLHmhMJP90kmt9ANESIHCukPxc6ecDEZXIo7C2rica9P3H/ew==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.208.0.tgz",
+      "integrity": "sha512-MkrCvaZhTb1qZCjcDH73t5n43h0Kr0GS+30lpXZ9PAnHJZPqv+vhWFPK0ZsFe1XktbS0WOoDR4ED+lWm0Dw7Rg==",
       "dependencies": {
         "mnemonist": "0.38.3",
         "tslib": "^2.3.1"
@@ -2198,14 +2933,90 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.201.0.tgz",
-      "integrity": "sha512-EHQ+AH/bflmfM2qDN3Aa2ufhw2irv6+FE/13yW09KsunaKiuSyg7Clh6+T8ESw3fCaI4IE2ol0d6HNwJ4JLOVQ==",
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.234.0.tgz",
+      "integrity": "sha512-HNZJbxXrSJfITJjAisqrju7T4S7U186xcmYr28CZX9XQNm6fc/bxcqj+8JRntWsekiJYyTvQLIrKxiCaa+TA9A==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.201.0",
-        "@aws-sdk/endpoint-cache": "3.201.0",
-        "@aws-sdk/protocol-http": "3.201.0",
-        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/endpoint-cache": "3.208.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+      "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+      "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/types": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+      "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+      "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -3018,6 +3829,31 @@
       }
     },
     "node_modules/@aws-sdk/util-middleware/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
+    "node_modules/@aws-sdk/util-retry": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
+      "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-retry/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-retry/node_modules/tslib": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
@@ -12913,72 +13749,666 @@
       }
     },
     "@aws-sdk/client-dynamodb": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.201.0.tgz",
-      "integrity": "sha512-RyZmvjhd99FgBnMLy5yirJCwiHGyCfHmZq332SUNL6nyWVbEUBAIi7/xiE4OPwScMpbE1iilJYCxcWey2gZdIw==",
+      "version": "3.241.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.241.0.tgz",
+      "integrity": "sha512-UFbX6KXHy18liDcFbKu/HUQdxDeAeGjl/HBFQ6tXq4eRx0tfMSsBZYNDJZl2T+bUpbBIi1Qzc7cH/g3FOO1vQQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.201.0",
-        "@aws-sdk/config-resolver": "3.201.0",
-        "@aws-sdk/credential-provider-node": "3.201.0",
-        "@aws-sdk/fetch-http-handler": "3.201.0",
-        "@aws-sdk/hash-node": "3.201.0",
-        "@aws-sdk/invalid-dependency": "3.201.0",
-        "@aws-sdk/middleware-content-length": "3.201.0",
-        "@aws-sdk/middleware-endpoint": "3.201.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.201.0",
-        "@aws-sdk/middleware-host-header": "3.201.0",
-        "@aws-sdk/middleware-logger": "3.201.0",
-        "@aws-sdk/middleware-recursion-detection": "3.201.0",
-        "@aws-sdk/middleware-retry": "3.201.0",
-        "@aws-sdk/middleware-serde": "3.201.0",
-        "@aws-sdk/middleware-signing": "3.201.0",
-        "@aws-sdk/middleware-stack": "3.201.0",
-        "@aws-sdk/middleware-user-agent": "3.201.0",
-        "@aws-sdk/node-config-provider": "3.201.0",
-        "@aws-sdk/node-http-handler": "3.201.0",
-        "@aws-sdk/protocol-http": "3.201.0",
-        "@aws-sdk/smithy-client": "3.201.0",
-        "@aws-sdk/types": "3.201.0",
-        "@aws-sdk/url-parser": "3.201.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "@aws-sdk/util-base64-node": "3.201.0",
+        "@aws-sdk/client-sts": "3.241.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.241.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.234.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.201.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.201.0",
-        "@aws-sdk/util-defaults-mode-node": "3.201.0",
-        "@aws-sdk/util-endpoints": "3.201.0",
-        "@aws-sdk/util-user-agent-browser": "3.201.0",
-        "@aws-sdk/util-user-agent-node": "3.201.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.241.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.201.0",
-        "@aws-sdk/util-waiter": "3.201.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/util-waiter": "3.226.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
       "dependencies": {
-        "@aws-sdk/middleware-endpoint": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.201.0.tgz",
-          "integrity": "sha512-F3JlXo5GusbeZR956hA9VxmDxUeg77Xh6o8fveAE2+G4Bjcb1iq9jPNlw6A14vDj3oTKenv2LLnjL2OIfl6hRA==",
+        "@aws-sdk/abort-controller": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
+          "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
           "requires": {
-            "@aws-sdk/middleware-serde": "3.201.0",
-            "@aws-sdk/protocol-http": "3.201.0",
-            "@aws-sdk/signature-v4": "3.201.0",
-            "@aws-sdk/types": "3.201.0",
-            "@aws-sdk/url-parser": "3.201.0",
-            "@aws-sdk/util-config-provider": "3.201.0",
-            "@aws-sdk/util-middleware": "3.201.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.241.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
+          "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.234.0",
+            "@aws-sdk/fetch-http-handler": "3.226.0",
+            "@aws-sdk/hash-node": "3.226.0",
+            "@aws-sdk/invalid-dependency": "3.226.0",
+            "@aws-sdk/middleware-content-length": "3.226.0",
+            "@aws-sdk/middleware-endpoint": "3.226.0",
+            "@aws-sdk/middleware-host-header": "3.226.0",
+            "@aws-sdk/middleware-logger": "3.226.0",
+            "@aws-sdk/middleware-recursion-detection": "3.226.0",
+            "@aws-sdk/middleware-retry": "3.235.0",
+            "@aws-sdk/middleware-serde": "3.226.0",
+            "@aws-sdk/middleware-stack": "3.226.0",
+            "@aws-sdk/middleware-user-agent": "3.226.0",
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/node-http-handler": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/smithy-client": "3.234.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/url-parser": "3.226.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+            "@aws-sdk/util-defaults-mode-node": "3.234.0",
+            "@aws-sdk/util-endpoints": "3.241.0",
+            "@aws-sdk/util-retry": "3.229.0",
+            "@aws-sdk/util-user-agent-browser": "3.226.0",
+            "@aws-sdk/util-user-agent-node": "3.226.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.241.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
+          "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.234.0",
+            "@aws-sdk/fetch-http-handler": "3.226.0",
+            "@aws-sdk/hash-node": "3.226.0",
+            "@aws-sdk/invalid-dependency": "3.226.0",
+            "@aws-sdk/middleware-content-length": "3.226.0",
+            "@aws-sdk/middleware-endpoint": "3.226.0",
+            "@aws-sdk/middleware-host-header": "3.226.0",
+            "@aws-sdk/middleware-logger": "3.226.0",
+            "@aws-sdk/middleware-recursion-detection": "3.226.0",
+            "@aws-sdk/middleware-retry": "3.235.0",
+            "@aws-sdk/middleware-serde": "3.226.0",
+            "@aws-sdk/middleware-stack": "3.226.0",
+            "@aws-sdk/middleware-user-agent": "3.226.0",
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/node-http-handler": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/smithy-client": "3.234.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/url-parser": "3.226.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+            "@aws-sdk/util-defaults-mode-node": "3.234.0",
+            "@aws-sdk/util-endpoints": "3.241.0",
+            "@aws-sdk/util-retry": "3.229.0",
+            "@aws-sdk/util-user-agent-browser": "3.226.0",
+            "@aws-sdk/util-user-agent-node": "3.226.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.241.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
+          "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.234.0",
+            "@aws-sdk/credential-provider-node": "3.241.0",
+            "@aws-sdk/fetch-http-handler": "3.226.0",
+            "@aws-sdk/hash-node": "3.226.0",
+            "@aws-sdk/invalid-dependency": "3.226.0",
+            "@aws-sdk/middleware-content-length": "3.226.0",
+            "@aws-sdk/middleware-endpoint": "3.226.0",
+            "@aws-sdk/middleware-host-header": "3.226.0",
+            "@aws-sdk/middleware-logger": "3.226.0",
+            "@aws-sdk/middleware-recursion-detection": "3.226.0",
+            "@aws-sdk/middleware-retry": "3.235.0",
+            "@aws-sdk/middleware-sdk-sts": "3.226.0",
+            "@aws-sdk/middleware-serde": "3.226.0",
+            "@aws-sdk/middleware-signing": "3.226.0",
+            "@aws-sdk/middleware-stack": "3.226.0",
+            "@aws-sdk/middleware-user-agent": "3.226.0",
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/node-http-handler": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/smithy-client": "3.234.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/url-parser": "3.226.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+            "@aws-sdk/util-defaults-mode-node": "3.234.0",
+            "@aws-sdk/util-endpoints": "3.241.0",
+            "@aws-sdk/util-retry": "3.229.0",
+            "@aws-sdk/util-user-agent-browser": "3.226.0",
+            "@aws-sdk/util-user-agent-node": "3.226.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "fast-xml-parser": "4.0.11",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+          "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
+          "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
+          "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/url-parser": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.241.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
+          "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.226.0",
+            "@aws-sdk/credential-provider-imds": "3.226.0",
+            "@aws-sdk/credential-provider-process": "3.226.0",
+            "@aws-sdk/credential-provider-sso": "3.241.0",
+            "@aws-sdk/credential-provider-web-identity": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.241.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
+          "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.226.0",
+            "@aws-sdk/credential-provider-imds": "3.226.0",
+            "@aws-sdk/credential-provider-ini": "3.241.0",
+            "@aws-sdk/credential-provider-process": "3.226.0",
+            "@aws-sdk/credential-provider-sso": "3.241.0",
+            "@aws-sdk/credential-provider-web-identity": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
+          "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.241.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
+          "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.241.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/token-providers": "3.241.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
+          "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
+          "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/querystring-builder": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
+          "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
+          "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
+          "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-endpoint": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
+          "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+          "requires": {
+            "@aws-sdk/middleware-serde": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/signature-v4": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/url-parser": "3.226.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
+          "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
+          "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
+          "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.235.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
+          "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/service-error-classification": "3.229.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "@aws-sdk/util-retry": "3.229.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
+          "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/signature-v4": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
+          "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
+          "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/signature-v4": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
+          "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
+          "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
+          "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
+          "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/querystring-builder": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+          "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+          "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+          "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+          "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.229.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+          "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+          "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+          "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
+          "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.241.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
+          "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+          "requires": {
+            "@aws-sdk/client-sso-oidc": "3.241.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+          "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+          "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
+          "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
+          "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.234.0",
+            "@aws-sdk/credential-provider-imds": "3.226.0",
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
             "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/util-endpoints": {
-          "version": "3.201.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.201.0.tgz",
-          "integrity": "sha512-EbXtjhdHfyEgDHrfduEmukMLls0cEamJ5VlUX5u1gPXHuT7Ju78+t6ig3BnMnmhaePIO5voNC+gZU5J29g+6cg==",
+          "version": "3.241.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
+          "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
           "requires": {
-            "@aws-sdk/types": "3.201.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+          "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
+          "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
+          "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+          "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-waiter": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
+          "integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
             "tslib": "^2.3.1"
           }
         },
@@ -13870,9 +15300,9 @@
       }
     },
     "@aws-sdk/endpoint-cache": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.201.0.tgz",
-      "integrity": "sha512-QgT4Wm19yQ/HbvxNeYaR7m9uEYhW+0YY9nSpnRLHmhMJP90kmt9ANESIHCukPxc6ecDEZXIo7C2rica9P3H/ew==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.208.0.tgz",
+      "integrity": "sha512-MkrCvaZhTb1qZCjcDH73t5n43h0Kr0GS+30lpXZ9PAnHJZPqv+vhWFPK0ZsFe1XktbS0WOoDR4ED+lWm0Dw7Rg==",
       "requires": {
         "mnemonist": "0.38.3",
         "tslib": "^2.3.1"
@@ -14087,17 +15517,75 @@
       }
     },
     "@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.201.0.tgz",
-      "integrity": "sha512-EHQ+AH/bflmfM2qDN3Aa2ufhw2irv6+FE/13yW09KsunaKiuSyg7Clh6+T8ESw3fCaI4IE2ol0d6HNwJ4JLOVQ==",
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.234.0.tgz",
+      "integrity": "sha512-HNZJbxXrSJfITJjAisqrju7T4S7U186xcmYr28CZX9XQNm6fc/bxcqj+8JRntWsekiJYyTvQLIrKxiCaa+TA9A==",
       "requires": {
-        "@aws-sdk/config-resolver": "3.201.0",
-        "@aws-sdk/endpoint-cache": "3.201.0",
-        "@aws-sdk/protocol-http": "3.201.0",
-        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/endpoint-cache": "3.208.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/config-resolver": {
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+          "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+          "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+          "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+          "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
         "tslib": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -14724,6 +16212,27 @@
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
+      }
+    },
+    "@aws-sdk/util-retry": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
+      "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+      "requires": {
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/service-error-classification": {
+          "version": "3.229.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+          "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg=="
+        },
         "tslib": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -18259,6 +19768,7 @@
     "gds-di-onboarding-dynamo-api": {
       "version": "file:backend/dynamo-api",
       "requires": {
+        "@aws-sdk/client-dynamodb": "*",
         "@aws-sdk/client-lambda": "^3.160.0",
         "@aws-sdk/client-sfn": "^3.160.0",
         "@aws-sdk/client-sns": "^3.162.0",


### PR DESCRIPTION
Backend changes

Don't add post_logout_redirect_uris to payloads for registering client and creating service-client.

Also add aws-dynamo package which was missing from package.json

No changes made to frontend to avoid merge conflicts with [SSE-2379 - Fix Medium accessibility issues](https://github.com/alphagov/di-onboarding-self-service-experience/pull/198/files#top) - some work will need to be done to conditionally insert 'Not yet added' or something; currently it's just left blank.