### PR TITLE
BAU Fix public key utils

### DIFF
--- a/express/src/lib/publicKeyUtils.ts
+++ b/express/src/lib/publicKeyUtils.ts
@@ -7,18 +7,16 @@ export default function getAuthApiCompliantPublicKey(publicKey: string): string 
     // assume PEM with headers
     try {
         createPublicKey({key: publicKey, format: "pem"});
-        return publicKey.replace(BEGIN, "").replace(END, "").replace("\n", "").replace("\r", "");
-    } catch (err) {
-        console.error(`Failed to convert\n${publicKey}`);
-    }
-
+        return publicKey.replace(BEGIN, "").replace(END, "").replace(/\n/g, "").replace(/\r/g, "");
+    } catch (ignored) {}
+    // assume they didn't supply headers
     const publicKeyWithHeaders = `${BEGIN}\n${publicKey}\n${END}\n`;
+
     try {
         createPublicKey({key: publicKeyWithHeaders, format: "pem"});
-        return publicKeyWithHeaders.replace(BEGIN, "").replace(END, "").replace("\n", "").replace("\r", "");
+        return publicKeyWithHeaders.replace(BEGIN, "").replace(END, "").replace(/\n/g, "").replace(/\r/g, "");
     } catch (err) {
-        console.error(`Failed to convert\n${publicKeyWithHeaders}`);
+        console.error(err);
+        throw new Error(`Failed to convert\n${publicKey}\n`);
     }
-
-    throw new Error(`Failed to convert\n${publicKey}\n`);
 }

--- a/express/tests/lib/publicKeyUtils.test.ts
+++ b/express/tests/lib/publicKeyUtils.test.ts
@@ -16,11 +16,14 @@ export const VALID_PUBLIC_KEY_WITH_HEADERS =
     "yUsDFW32iN5s4jnawIRZQUSM77t9McHS7QOTLFkUDNxHAgMBAAE=\n" +
     "-----END PUBLIC KEY-----\n";
 
-// These seem to actually work in the app so it probably has something to do with the \n at the end of some lines.
 describe("public keys are properly prepared for the auth API call", () => {
-    it.skip("accepts a valid public key with no headers and no line breaks", () => {
+    it("accepts a valid public key with no headers and no line breaks", () => {
         expect(getAuthApiCompliantPublicKey(VALID_PUBLIC_KEY_NO_HEADERS_OR_LINE_BREAKS)).toEqual(
-            VALID_PUBLIC_KEY_NO_HEADERS_OR_LINE_BREAKS + "\n"
+            VALID_PUBLIC_KEY_NO_HEADERS_OR_LINE_BREAKS
         );
+    });
+
+    it("accepts a valid public key with headers and line breaks", () => {
+        expect(getAuthApiCompliantPublicKey(VALID_PUBLIC_KEY_WITH_HEADERS)).toEqual(VALID_PUBLIC_KEY_NO_HEADERS_OR_LINE_BREAKS);
     });
 });


### PR DESCRIPTION
Do global find and replace on returned public key.

Change logging to only log at the end.

Co-authored by: Karol Gancarz <karol.gancarz@digital.cabinet-office.gov.uk>