### PR TITLE
SSE-2310 Self Service development domains

### DIFF
--- a/backend/domains/development/template.yaml
+++ b/backend/domains/development/template.yaml
@@ -1,0 +1,35 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  DNS configuration for self-service development and preview sub domains deployed in development account
+Transform:
+  - AWS::Serverless-2016-10-31
+
+Resources:
+  SignInServiceDevelopmentHostedZone:
+    Type: AWS::Route53::HostedZone
+    Properties:
+      HostedZoneConfig:
+        Comment: Hosted zone for sign-in.service.gov.uk development sub-domain
+      Name: development.sign-in.service.gov.uk.
+
+
+  SignInServicePreviewHostedZone:
+    Type: AWS::Route53::HostedZone
+    Properties:
+      HostedZoneConfig:
+        Comment: Hosted zone for sign-in.service.gov.uk preview sub-domain
+      Name: preview.sign-in.service.gov.uk.
+
+
+Outputs:
+  DevelopmentHostedZone:
+    Description: Hosted Zone for sign-in.service.gov.uk development sub-domain
+    Value: !Ref SignInServiceDevelopmentHostedZone
+    Export:
+      Name: SignInServiceDevelopmentHostedZone
+
+  PreviewHostedZone:
+    Description: Hosted Zone for sign-in.service.gov.uk preview sub-domain
+    Value: !Ref SignInServicePreviewHostedZone
+    Export:
+      Name: SignInServicePreviewHostedZone

--- a/backend/domains/production/template.yaml
+++ b/backend/domains/production/template.yaml
@@ -64,6 +64,23 @@ Resources:
             - ns-1494.awsdns-58.org.
             - ns-152.awsdns-19.com.
 
+        - Name: development.sign-in.service.gov.uk.
+          Type: NS
+          TTL: 60
+          ResourceRecords:
+            - ns-1673.awsdns-17.co.uk.
+            - ns-1520.awsdns-62.org.
+            - ns-456.awsdns-57.com.
+            - ns-760.awsdns-31.net.
+
+        - Name: preview.sign-in.service.gov.uk.
+          Type: NS
+          TTL: 60
+          ResourceRecords:
+            - ns-586.awsdns-09.net.
+            - ns-372.awsdns-46.com.
+            - ns-1074.awsdns-06.org.
+            - ns-1987.awsdns-56.co.uk.
 Outputs:
   HostedZone:
     Description: Hosted Zone for sign-in.service.gov.uk


### PR DESCRIPTION
Create hosted zones for `development.sign-in.service.gov.uk` and `preview.sign-in.service.gov.uk`.

Create hosted zones to be applied in the development account for the development and preview sub domains.

Update the production hosted zone with NS records pointing to the nameservers in the new hosted zones so that queries will resolve properly.

The development and preview templates have been applied and the nameservers can be checked in Route53 to make sure that the production hosted zone is correct in this PR before it is also applied.