### PR TITLE
SSE-2365 make Change service name work properly

### DIFF
--- a/express/src/routes/testing-routes.ts
+++ b/express/src/routes/testing-routes.ts
@@ -442,8 +442,11 @@ router.post("/resend-email-code", async (req, res) => {
 });
 
 // Testing route for 'Team members' page
-router.get("/team-members", (req, res) => {
+router.get("/team-members/:serviceId/:selfServiceClientId/:clientId", (req, res) => {
     res.render("service-details/team-members.njk", {
+        serviceId: req.params.serviceId,
+        selfServiceClientId: req.params.selfServiceClientId,
+        clientId: req.params.clientId,
         serviceName: "Frontend Test Service",
         users: [
             {

--- a/express/src/routes/testing-routes.ts
+++ b/express/src/routes/testing-routes.ts
@@ -447,7 +447,7 @@ router.get("/team-members/:serviceId/:selfServiceClientId/:clientId", (req, res)
         serviceId: req.params.serviceId,
         selfServiceClientId: req.params.selfServiceClientId,
         clientId: req.params.clientId,
-        serviceName: "Frontend Test Service",
+        serviceName: req.session.serviceName,
         users: [
             {
                 userPersonalName: "Courtney Toth",

--- a/express/src/services/lambda-facade/StubLambdaFacade.ts
+++ b/express/src/services/lambda-facade/StubLambdaFacade.ts
@@ -67,6 +67,9 @@ class StubLambdaFacade implements LambdaFacadeInterface {
         if (updates.public_key) {
             this.publicKey = updates.public_key;
         }
+        if (updates.service_name) {
+            this.serviceName = updates.service_name;
+        }
         return Promise.resolve({} as AxiosResponse);
     }
 

--- a/express/src/views/service-details/layout-service-details.njk
+++ b/express/src/views/service-details/layout-service-details.njk
@@ -35,7 +35,7 @@
               <a class="govuk-link govuk-link--no-visited-state" href="/client-details/{{ serviceId }}">Client details</a>
             </li>
             <li class="side-navigation__item{% if sidebarActiveItem == 'team-members' %} side-navigation__item--active{% endif %}">
-              <a class="govuk-link govuk-link--no-visited-state" href="/team-members">Team members</a>
+              <a class="govuk-link govuk-link--no-visited-state" href="/team-members/{{ serviceId }}/{{ selfServiceClientId }}/{{ clientId }}">Team members</a>
             </li>
             <li class="side-navigation__item{% if sidebarActiveItem == 'private-beta' %} side-navigation__item--active{% endif %}">
               <a class="govuk-link govuk-link--no-visited-state" href="/private-beta/{{ serviceId }}/{{ selfServiceClientId }}/{{ clientId }}">


### PR DESCRIPTION
`layout-service-details.njk` needs some IDs passed in for some links to work properly.  The Team members page was not being rendered with those values included or with the serviceName which comes from the session.

The Team members route did not include the parameters for `serviceId`, `selfServiceClientId` or `clientId` so it could not render the Change service link properly and couldn't propagate those IDs to the pages referenced in the side bar.

Change the route to include the parameters and make sure they are added to the rendering code so they can be added to URLs.

Change `views/service-details/layout-service-details.njk` so missing IDs are added to the team-members URL as parameters.

Make sure the serviceName held in the session is passed when rendering the Team members page

Update the StubLambdaFacade to keep changes to service name (which I thought I'd already done but it seems not!).
