### PR TITLE
SSE-2386 Public Key not displayed in text area

### DIFF
--- a/express/features/support/steps/client-steps.ts
+++ b/express/features/support/steps/client-steps.ts
@@ -1,5 +1,7 @@
-import {Given} from "@cucumber/cucumber";
+import {Given, Then} from "@cucumber/cucumber";
 import {clickSubmitButton, enterTextIntoTextInput} from "./shared-functions";
+import {strict as assert} from "assert";
+import {TestContext} from "../test-setup";
 
 const VALID_PUBLIC_KEY =
     "-----BEGIN PUBLIC KEY-----\n" +
@@ -29,4 +31,10 @@ Given("the user submits a valid public key with headers", async function () {
 Given("the user submits a valid public key without headers", async function () {
     await enterTextIntoTextInput(this.page, VALID_PUBLIC_KEY_WITHOUT_HEADERS, "serviceUserPublicKey");
     await clickSubmitButton(this.page);
+});
+
+Then("they should see the public key they just entered in the textarea", async function (this: TestContext) {
+    const textArea = await this.page.$("#serviceUserPublicKey");
+    const textAreaContent = await this.page.evaluate(element => element.textContent, textArea);
+    assert.equal(textAreaContent, VALID_PUBLIC_KEY_WITHOUT_HEADERS.replace(/\n/g, ""));
 });

--- a/express/features/update-client.feature
+++ b/express/features/update-client.feature
@@ -19,3 +19,11 @@ Feature: Users can update clients
       And the user submits a valid public key without headers
       Then they should be redirected to a page with path starting with "client-details"
       And they should see the text "You have changed your public key"
+
+    Scenario: the user submits a valid public key and then thinks maybe they need to edit it by hand
+      Given they click on the link with the url that starts with "/change-public-key/"
+      And the user submits a valid public key without headers
+      Then they should be redirected to a page with path starting with "client-details"
+      And they should see the text "You have changed your public key"
+      And they click on the link with the url that starts with "/change-public-key/"
+      Then they should see the public key they just entered in the textarea

--- a/express/src/controllers/manage-account.ts
+++ b/express/src/controllers/manage-account.ts
@@ -63,19 +63,19 @@ export const showClient = async function (req: Request, res: Response) {
         postLogoutRedirectUrls: client.postLogoutUris.join(" "),
         urls: {
             // TODO changeClientName is currently not used
-            changeClientName: `/change-client-name/${serviceId}/${selfServiceClientId}/${authClientId}?clientName=${encodeURI(
+            changeClientName: `/change-client-name/${serviceId}/${selfServiceClientId}/${authClientId}?clientName=${encodeURIComponent(
                 client.clientName
             )}`,
-            changeRedirectUris: `/change-redirect-uris/${serviceId}/${selfServiceClientId}/${authClientId}?redirectUris=${encodeURI(
+            changeRedirectUris: `/change-redirect-uris/${serviceId}/${selfServiceClientId}/${authClientId}?redirectUris=${encodeURIComponent(
                 client.redirectUris.join(" ")
             )}`,
-            changeUserAttributes: `/change-user-attributes/${serviceId}/${selfServiceClientId}/${authClientId}?userAttributes=${encodeURI(
+            changeUserAttributes: `/change-user-attributes/${serviceId}/${selfServiceClientId}/${authClientId}?userAttributes=${encodeURIComponent(
                 client.scopes.join(" ")
             )}`,
-            changePublicKey: `/change-public-key/${serviceId}/${selfServiceClientId}/${authClientId}?publicKey=${encodeURI(
-                client.publicKey
+            changePublicKey: `/change-public-key/${serviceId}/${selfServiceClientId}/${authClientId}?publicKey=${encodeURIComponent(
+                userPublicKey
             )}`,
-            changePostLogoutUris: `/change-post-logout-uris/${serviceId}/${selfServiceClientId}/${authClientId}?redirectUris=${encodeURI(
+            changePostLogoutUris: `/change-post-logout-uris/${serviceId}/${selfServiceClientId}/${authClientId}?redirectUris=${encodeURIComponent(
                 client.postLogoutUris.join(" ")
             )}`
         }

--- a/express/src/routes/testing-routes.ts
+++ b/express/src/routes/testing-routes.ts
@@ -163,7 +163,8 @@ router.get("/change-public-key/:serviceId/:selfServiceClientId/:clientId", (req,
     res.render("service-details/change-public-key.njk", {
         serviceId: req.params.serviceId,
         selfServiceClientId: req.params.selfServiceClientId,
-        clientId: req.params.clientId
+        clientId: req.params.clientId,
+        values: {serviceUserPublicKey: req.query.publicKey}
     });
 });
 


### PR DESCRIPTION
Public Key data should be displayed in the text area used for entering public keys and you never know when you'll need to manually edit the public key you've already successfully stored.

Use correctly sanitised version of public key so comparisons work and the default isn't displayed.

Pass value to template.

Add test.