### PR TITLE
DFA-2463: Clean up frontend docker image

### DIFF
--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -11,6 +11,8 @@ on:
 concurrency:
   group: deploy-${{ github.head_ref || github.ref_name }}
 
+permissions: read-all
+
 jobs:
   delete-paas-deployment:
     name: Delete app preview
@@ -50,7 +52,6 @@ jobs:
     name: Delete Fargate deployment
     runs-on: ubuntu-latest
     environment: development
-    if: ${{ github.event_name == 'schedule' }}
 
     permissions:
       id-token: write
@@ -67,7 +68,18 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
+      - name: Delete docker image
+        if: ${{ github.event_name != 'schedule' }}
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        run: |
+          aws ecr batch-delete-image \
+            --repository-name self-service/frontend \
+            --image-ids imageTag="$BRANCH_NAME" \
+            --output text          
+
       - name: Clean up stale task definitions
+        if: ${{ github.event_name == 'schedule' }}
         uses: alphagov/di-github-actions/aws/ecs/deregister-stale-task-definitions@e0e43b4ca78aca47971596806a8f4693e6a84dc7
         with:
           family: self-service-frontend


### PR DESCRIPTION
Delete the docker image for the branch when closing a PR or running the workflow manually.

[Images are tagged with the branch name when they are deployed](https://github.com/alphagov/di-onboarding-self-service-experience/blob/92635c123b4c1e043a27df6abac0fea2f16cfc66/.github/workflows/deploy-to-fargate.yml#L44), so use that that to identify the image to delete.