### PR TITLE
SSE-2386 Display public key above text area, not in it

### DIFF
--- a/express/assets/css/app.scss
+++ b/express/assets/css/app.scss
@@ -249,3 +249,6 @@ code {
   margin-top: 15px;
 }
 
+.govuk-inset-text {
+  overflow-wrap: break-word;
+}

--- a/express/features/support/steps/client-steps.ts
+++ b/express/features/support/steps/client-steps.ts
@@ -33,8 +33,8 @@ Given("the user submits a valid public key without headers", async function () {
     await clickSubmitButton(this.page);
 });
 
-Then("they should see the public key they just entered in the textarea", async function (this: TestContext) {
-    const textArea = await this.page.$("#serviceUserPublicKey");
-    const textAreaContent = await this.page.evaluate(element => element.textContent, textArea);
-    assert.equal(textAreaContent, VALID_PUBLIC_KEY_WITHOUT_HEADERS.replace(/\n/g, ""));
+Then("they should see the public key they just entered in an inset text component", async function (this: TestContext) {
+    const publicKeyDiv = await this.page.$("div.govuk-inset-text");
+    const publicKey = await this.page.evaluate(element => element.textContent, publicKeyDiv);
+    assert.equal(publicKey.replace(/\n/g, "").trim(), VALID_PUBLIC_KEY_WITHOUT_HEADERS.replace(/\n/g, ""));
 });

--- a/express/features/update-client.feature
+++ b/express/features/update-client.feature
@@ -20,10 +20,10 @@ Feature: Users can update clients
       Then they should be redirected to a page with the path starting with "/client-details"
       And they should see the text "You have changed your public key"
 
-    Scenario: the user submits a valid public key and then thinks maybe they need to edit it by hand
+    Scenario: the user submits a valid public key and it is displayed on the update public key screen
       Given they click on the link with the URL starting with "/change-public-key/"
       And the user submits a valid public key without headers
       Then they should be redirected to a page with the path starting with "/client-details"
       And they should see the text "You have changed your public key"
       And they click on the link with the URL starting with "/change-public-key/"
-      Then they should see the public key they just entered in the textarea
+      Then they should see the public key they just entered in an inset text component

--- a/express/src/routes/testing-routes.ts
+++ b/express/src/routes/testing-routes.ts
@@ -164,7 +164,7 @@ router.get("/change-public-key/:serviceId/:selfServiceClientId/:clientId", (req,
         serviceId: req.params.serviceId,
         selfServiceClientId: req.params.selfServiceClientId,
         clientId: req.params.clientId,
-        values: {serviceUserPublicKey: req.query.publicKey}
+        serviceUserPublicKey: req.query.publicKey
     });
 });
 

--- a/express/src/views/service-details/change-public-key.njk
+++ b/express/src/views/service-details/change-public-key.njk
@@ -1,4 +1,5 @@
 {% extends "./base-form-service-details.njk" %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% set pageTitle = "Change public key" %}
 
@@ -9,7 +10,9 @@
     <a href="https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/generate-a-key/" class="govuk-link" rel="noreferrer noopener" target="_blank">
       generate a key pair (opens in new tab)</a> and add the public key. This is so our services can securely send messages to each other.
   </p>
-
+  {{ govukInsetText({
+    text: serviceUserPublicKey
+  }) if serviceUserPublicKey }}
 {% endblock %}
 
 {% block formInputs %}


### PR DESCRIPTION
I should never have rendered the public key inside the textarea.  Now it goes in the right place.