### PR TITLE
SSE-2386 Show public key when there have been input errors

### DIFF
--- a/express/features/support/steps/client-steps.ts
+++ b/express/features/support/steps/client-steps.ts
@@ -34,7 +34,7 @@ Given("the user submits a valid public key without headers", async function () {
 });
 
 Then("they should see the public key they just entered in an inset text component", async function (this: TestContext) {
-    const publicKeyDiv = await this.page.$("div.govuk-inset-text");
-    const publicKey = await this.page.evaluate(element => element.textContent, publicKeyDiv);
+    const publicKeySpan = await this.page.$("p#current-public-key");
+    const publicKey = await this.page.evaluate(element => element.textContent, publicKeySpan);
     assert.equal(publicKey.replace(/\n/g, "").trim(), VALID_PUBLIC_KEY_WITHOUT_HEADERS.replace(/\n/g, ""));
 });

--- a/express/src/middleware/convertPublicKeyForAuth.ts
+++ b/express/src/middleware/convertPublicKeyForAuth.ts
@@ -12,9 +12,9 @@ export function convertPublicKeyForAuth(req: Request, res: Response, next: NextF
             clientId: req.params.clientId,
             errorMessages: {
                 serviceUserPublicKey: "Enter a valid public key"
-            }
+            },
+            serviceUserPublicKey: req.query.publicKey
         });
-
         return;
     }
 

--- a/express/src/views/service-details/change-public-key.njk
+++ b/express/src/views/service-details/change-public-key.njk
@@ -3,6 +3,11 @@
 
 {% set pageTitle = "Change public key" %}
 
+{% set publicKeyBlock %}
+  <p class="govuk-body govuk-!-static-margin-bottom-0 govuk-!-font-weight-bold">Current public key</p>
+  <p class="govuk-body govuk-!-static-margin-bottom-0" id="current-public-key">{{ serviceUserPublicKey }}</p>
+{% endset %}
+
 {% block beforeForm %}
   <h1 class="govuk-heading-l govuk-!-margin-top-3">Change your public key</h1>
 
@@ -11,7 +16,7 @@
       generate a key pair (opens in new tab)</a> and add the public key. This is so our services can securely send messages to each other.
   </p>
   {{ govukInsetText({
-    text: serviceUserPublicKey
+    html: publicKeyBlock
   }) if serviceUserPublicKey }}
 {% endblock %}
 


### PR DESCRIPTION
Make sure public key can be rendered if there are inline errors

Make text for "Current public key" strong.