### PR TITLE
SSE-2463: Show progress when running acceptance tests in GitHub Actions

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Run checkov
-        uses: alphagov/di-github-actions/code-quality/run-checkov@73e10d75ac678988b8bd444ffc07b0fcb0cc39d0
+        uses: alphagov/di-github-actions/code-quality/run-checkov@ad7ff02640e256ecc3f677bc876ac0a22ed25964
         with:
           skip-checks: CKV_SECRET_6
 
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Run shell checks
-        uses: alphagov/di-github-actions/code-quality/check-shell-scripts@73e10d75ac678988b8bd444ffc07b0fcb0cc39d0
+        uses: alphagov/di-github-actions/code-quality/check-shell-scripts@ad7ff02640e256ecc3f677bc876ac0a22ed25964
 
   check-linting:
     name: Linting
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check linting and formatting
-        uses: alphagov/di-github-actions/code-quality/check-linting@73e10d75ac678988b8bd444ffc07b0fcb0cc39d0
+        uses: alphagov/di-github-actions/code-quality/check-linting@ad7ff02640e256ecc3f677bc876ac0a22ed25964
 
   check-vulnerabilities:
     name: Vulnerabilities
@@ -44,4 +44,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Run security audit
-        uses: alphagov/di-github-actions/code-quality/run-security-audit@73e10d75ac678988b8bd444ffc07b0fcb0cc39d0
+        uses: alphagov/di-github-actions/code-quality/run-security-audit@ad7ff02640e256ecc3f677bc876ac0a22ed25964

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -18,7 +18,7 @@ jobs:
     concurrency: deploy-paas-${{ github.head_ref || github.ref_name }}
     steps:
       - name: PaaS login
-        uses: alphagov/di-github-actions/paas/log-in-to-paas@73e10d75ac678988b8bd444ffc07b0fcb0cc39d0
+        uses: alphagov/di-github-actions/paas/log-in-to-paas@ad7ff02640e256ecc3f677bc876ac0a22ed25964
         with:
           cf-org-name: gds-digital-identity-onboarding
           cf-space-name: self-service-preview
@@ -27,7 +27,7 @@ jobs:
 
       - name: Get app name
         if: ${{ github.event_name != 'schedule' }}
-        uses: alphagov/di-github-actions/beautify-branch-name@73e10d75ac678988b8bd444ffc07b0fcb0cc39d0
+        uses: alphagov/di-github-actions/beautify-branch-name@ad7ff02640e256ecc3f677bc876ac0a22ed25964
         with:
           downcase: true
           length-limit: 63
@@ -42,7 +42,7 @@ jobs:
 
       - name: Clean up stale deployments
         if: ${{ github.event_name == 'schedule' }}
-        uses: alphagov/di-github-actions/paas/delete-stale-apps@73e10d75ac678988b8bd444ffc07b0fcb0cc39d0
+        uses: alphagov/di-github-actions/paas/delete-stale-apps@ad7ff02640e256ecc3f677bc876ac0a22ed25964
         with:
           age-threshold-days: 30
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Clean up stale task definitions
         if: ${{ github.event_name == 'schedule' }}
-        uses: alphagov/di-github-actions/aws/ecs/deregister-stale-task-definitions@73e10d75ac678988b8bd444ffc07b0fcb0cc39d0
+        uses: alphagov/di-github-actions/aws/ecs/deregister-stale-task-definitions@ad7ff02640e256ecc3f677bc876ac0a22ed25964
         with:
           family: self-service-frontend
           container: self-service-frontend

--- a/.github/workflows/deploy-to-fargate.yml
+++ b/.github/workflows/deploy-to-fargate.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Push Docker image
         id: push-docker-image
-        uses: alphagov/di-github-actions/aws/ecr/build-docker-image@73e10d75ac678988b8bd444ffc07b0fcb0cc39d0
+        uses: alphagov/di-github-actions/aws/ecr/build-docker-image@ad7ff02640e256ecc3f677bc876ac0a22ed25964
         with:
           repository: self-service/frontend
           image-version: ${{ github.sha }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Register task definition
         id: register-task-definition
-        uses: alphagov/di-github-actions/aws/ecs/register-task-definition@73e10d75ac678988b8bd444ffc07b0fcb0cc39d0
+        uses: alphagov/di-github-actions/aws/ecs/register-task-definition@ad7ff02640e256ecc3f677bc876ac0a22ed25964
         with:
           task-definition: express/task-definition.json
           container: self-service-frontend

--- a/.github/workflows/deploy-to-paas.yml
+++ b/.github/workflows/deploy-to-paas.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Push to PaaS
         id: push-to-paas
-        uses: alphagov/di-github-actions/paas/deploy-app@73e10d75ac678988b8bd444ffc07b0fcb0cc39d0
+        uses: alphagov/di-github-actions/paas/deploy-app@ad7ff02640e256ecc3f677bc876ac0a22ed25964
         with:
           url: ${{ inputs.url }}
           app-name-prefix: ${{ inputs.app-name-prefix }}

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -8,6 +8,10 @@ on:
 permissions: read-all
 concurrency: deploy-paas-${{ github.head_ref || github.ref_name }}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   run-acceptance-tests:
     name: Acceptance
@@ -28,6 +32,26 @@ jobs:
         run: npm install
 
       - name: Run cucumber tests
+        id: run-tests
+        shell: bash
         env:
           HOST: ${{ inputs.host }}
-        run: npm run cucumber
+          REPORT: ${{ runner.temp }}/acceptance-tests.report
+        run: |
+          features=(features/*.feature)
+          
+          for feature in "${features[@]}"; do
+            [[ ${idx:-} ]] && idx=$((idx + 1)) && echo | tee heading || idx=1
+            echo "#--- [$idx/${#features[@]}] ${feature#*/} ---#" | tee -a heading && echo >> heading
+            npm run cucumber -- --format summary:results "$feature" || cat heading results >> "$REPORT"
+          done
+          
+          [[ -s $REPORT ]] && exit 1 || exit 0
+
+      - name: Report test results
+        if: ${{ failure() && steps.run-tests.outcome == 'failure' }}
+        uses: alphagov/di-github-actions/report-step-result/print-file@ad7ff02640e256ecc3f677bc876ac0a22ed25964
+        with:
+          title: Acceptance tests
+          language: shell
+          file-path: ${{ runner.temp }}/acceptance-tests.report

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -6,6 +6,10 @@ concurrency:
   group: unit-tests-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   run-unit-tests:
     name: Unit
@@ -23,4 +27,7 @@ jobs:
         run: npm install
 
       - name: Run unit tests
-        run: npm run test
+        id: run-tests
+        env:
+          REPORT: ${{ runner.temp }}/unit-tests.report
+        run: npm run test -- --config infrastructure/ci/jest.config.ts

--- a/express/Dockerfile
+++ b/express/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:current-alpine
 WORKDIR /express
 
 ENV PORT=3000

--- a/infrastructure/ci/jest.config.ts
+++ b/infrastructure/ci/jest.config.ts
@@ -1,0 +1,7 @@
+import {Config} from "jest";
+import baseConfig from "../../jest.config";
+
+export default {
+    ...baseConfig,
+    reporters: [["github-actions", {silent: false}], "summary"]
+} as Config;

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -5,8 +5,8 @@
   },
   // Additional paths to lint not included by other tsconfig.json files
   "include": [
-    "./**/.*.js",
-    "./**/*.js",
-    "./**/*.ts"
+    "**/**/.*.js",
+    "**/**/*.js",
+    "**/**/*.ts"
   ]
 }


### PR DESCRIPTION
As we've added more acceptance tests, they now take more than 5 minutes to run in GHA. However, cucumber only prints output after all the tests have run, so we don't get any indication of progress. This can't really be fixed due to how cucumber works, but it can be improved by running the tests one feature at a time and printing the output after each.

Additionally, report failed features to the step summary.

For the unit tests, use the dedicated github-actions formatter for jest to get automatic reporting with annotations. This is configured by supplying the dedicated config file.

Adjust the global ts config to include all files not covered by any of the subprojects.