### PR TITLE
SSE-2463: Delete frontend docker image from ECR for a branch

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Run checkov
-        uses: alphagov/di-github-actions/code-quality/run-checkov@ad7ff02640e256ecc3f677bc876ac0a22ed25964
+        uses: alphagov/di-github-actions/code-quality/run-checkov@0296e8125a9293d4dfd393ebc83785147f5f5927
         with:
           skip-checks: CKV_SECRET_6
 
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Run shell checks
-        uses: alphagov/di-github-actions/code-quality/check-shell-scripts@ad7ff02640e256ecc3f677bc876ac0a22ed25964
+        uses: alphagov/di-github-actions/code-quality/check-shell-scripts@0296e8125a9293d4dfd393ebc83785147f5f5927
 
   check-linting:
     name: Linting
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check linting and formatting
-        uses: alphagov/di-github-actions/code-quality/check-linting@ad7ff02640e256ecc3f677bc876ac0a22ed25964
+        uses: alphagov/di-github-actions/code-quality/check-linting@0296e8125a9293d4dfd393ebc83785147f5f5927
 
   check-vulnerabilities:
     name: Vulnerabilities
@@ -44,4 +44,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Run security audit
-        uses: alphagov/di-github-actions/code-quality/run-security-audit@ad7ff02640e256ecc3f677bc876ac0a22ed25964
+        uses: alphagov/di-github-actions/code-quality/run-security-audit@0296e8125a9293d4dfd393ebc83785147f5f5927

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -18,7 +18,7 @@ jobs:
     concurrency: deploy-paas-${{ github.head_ref || github.ref_name }}
     steps:
       - name: PaaS login
-        uses: alphagov/di-github-actions/paas/log-in-to-paas@ad7ff02640e256ecc3f677bc876ac0a22ed25964
+        uses: alphagov/di-github-actions/paas/log-in-to-paas@0296e8125a9293d4dfd393ebc83785147f5f5927
         with:
           cf-org-name: gds-digital-identity-onboarding
           cf-space-name: self-service-preview
@@ -27,7 +27,7 @@ jobs:
 
       - name: Get app name
         if: ${{ github.event_name != 'schedule' }}
-        uses: alphagov/di-github-actions/beautify-branch-name@ad7ff02640e256ecc3f677bc876ac0a22ed25964
+        uses: alphagov/di-github-actions/beautify-branch-name@0296e8125a9293d4dfd393ebc83785147f5f5927
         with:
           downcase: true
           length-limit: 63
@@ -42,7 +42,7 @@ jobs:
 
       - name: Clean up stale deployments
         if: ${{ github.event_name == 'schedule' }}
-        uses: alphagov/di-github-actions/paas/delete-stale-apps@ad7ff02640e256ecc3f677bc876ac0a22ed25964
+        uses: alphagov/di-github-actions/paas/delete-stale-apps@0296e8125a9293d4dfd393ebc83785147f5f5927
         with:
           age-threshold-days: 30
 
@@ -57,36 +57,18 @@ jobs:
       contents: read
 
     steps:
-      - name: Assume AWS Role
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.GHA_AWS_ROLE_ARN }}
-          aws-region: eu-west-2
-
-      - name: Login to ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
       - name: Delete docker image
         if: ${{ github.event_name != 'schedule' }}
-        env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-        run: |
-          imageDigest=$(aws ecr list-images \
-            --repository-name self-service/frontend \
-            --filter tagStatus=TAGGED \
-            --query "imageIds[?imageTag=='$BRANCH_NAME'].imageDigest" \
-            --output text)
-          
-          aws ecr batch-delete-image \
-            --repository-name self-service/frontend \
-            --image-ids imageDigest="'$imageDigest'" \
-            --output text         
+        uses: alphagov/di-github-actions/aws/ecr/delete-docker-images@0296e8125a9293d4dfd393ebc83785147f5f5927
+        with:
+          aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}
+          repository: self-service/frontend
+          image-tags: ${{ github.head_ref || github.ref_name }}
 
       - name: Clean up stale task definitions
         if: ${{ github.event_name == 'schedule' }}
-        uses: alphagov/di-github-actions/aws/ecs/deregister-stale-task-definitions@ad7ff02640e256ecc3f677bc876ac0a22ed25964
+        uses: alphagov/di-github-actions/aws/ecs/deregister-stale-task-definitions@0296e8125a9293d4dfd393ebc83785147f5f5927
         with:
+          aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}
           family: self-service-frontend
           container: self-service-frontend
-          registry: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/deploy-to-fargate.yml
+++ b/.github/workflows/deploy-to-fargate.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Push Docker image
         id: push-docker-image
-        uses: alphagov/di-github-actions/aws/ecr/build-docker-image@ad7ff02640e256ecc3f677bc876ac0a22ed25964
+        uses: alphagov/di-github-actions/aws/ecr/build-docker-image@0296e8125a9293d4dfd393ebc83785147f5f5927
         with:
           repository: self-service/frontend
           image-version: ${{ github.sha }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Register task definition
         id: register-task-definition
-        uses: alphagov/di-github-actions/aws/ecs/register-task-definition@ad7ff02640e256ecc3f677bc876ac0a22ed25964
+        uses: alphagov/di-github-actions/aws/ecs/register-task-definition@0296e8125a9293d4dfd393ebc83785147f5f5927
         with:
           task-definition: express/task-definition.json
           container: self-service-frontend

--- a/.github/workflows/deploy-to-paas.yml
+++ b/.github/workflows/deploy-to-paas.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Push to PaaS
         id: push-to-paas
-        uses: alphagov/di-github-actions/paas/deploy-app@ad7ff02640e256ecc3f677bc876ac0a22ed25964
+        uses: alphagov/di-github-actions/paas/deploy-app@0296e8125a9293d4dfd393ebc83785147f5f5927
         with:
           url: ${{ inputs.url }}
           app-name-prefix: ${{ inputs.app-name-prefix }}

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Report test results
         if: ${{ failure() && steps.run-tests.outcome == 'failure' }}
-        uses: alphagov/di-github-actions/report-step-result/print-file@ad7ff02640e256ecc3f677bc876ac0a22ed25964
+        uses: alphagov/di-github-actions/report-step-result/print-file@0296e8125a9293d4dfd393ebc83785147f5f5927
         with:
           title: Acceptance tests
           language: shell


### PR DESCRIPTION
Use the latest docker actions to clean up ECR images.
Use the latest actions across the repo.