### PR TITLE
SSE-2491 Fix Public Key Bug

### DIFF
--- a/express/features/support/steps/client-steps.ts
+++ b/express/features/support/steps/client-steps.ts
@@ -14,6 +14,18 @@ const VALID_PUBLIC_KEY =
     "QQIDAQAB\n" +
     "-----END PUBLIC KEY-----\n";
 
+const VALID_PUBLIC_KEY_WITH_JUNK =
+    "-----BEGIN PUBLIC KEY-----\n" +
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzub4UEORDbGXh36oJCG+\n" +
+    "dD7PQpkiiyaCy8tn0mgB8GXgRyRjGRG4Xh0jU4mteNhFHyWxrdClZ7we7kqR025P\n" +
+    "ltXBorHgzZq6sHcUHyKKlQquLCEv1P0PuZ30P7uERf7xtkWMN2/s4hsG0It7/Wt0\n" +
+    "2o8uJAE1oWNbSN+a5d6nXLvfkgruGidNLtUnEAP7HR0hz9P4zNgp3hOgkaEX299S\n" +
+    "vS6Twgr/tzjAygi1AWE8hPImn0LBwHHjcXqSL39pk3YKOG0Na2ZY/FdlbTQP5iRU\n" +
+    "6CIY/e++fMVF1aignXW8rJN1xEiLhxAS4PLqpzXzZ6k5JW/rJiGC0KIKPcJ6xazx\n" +
+    "QQIDAQAB\n" +
+    "-----END PUBLIC KEY-----\n" +
+    "the crypto lib never reads this but we don't want it appended to the end of the auth compliant key";
+
 const VALID_PUBLIC_KEY_WITHOUT_HEADERS =
     "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzub4UEORDbGXh36oJCG+\n" +
     "dD7PQpkiiyaCy8tn0mgB8GXgRyRjGRG4Xh0jU4mteNhFHyWxrdClZ7we7kqR025P\n" +
@@ -25,6 +37,11 @@ const VALID_PUBLIC_KEY_WITHOUT_HEADERS =
 
 Given("the user submits a valid public key with headers", async function () {
     await enterTextIntoTextInput(this.page, VALID_PUBLIC_KEY, "serviceUserPublicKey");
+    await clickSubmitButton(this.page);
+});
+
+Given("the user submits a valid public key with headers and junk after the key", async function () {
+    await enterTextIntoTextInput(this.page, VALID_PUBLIC_KEY_WITH_JUNK, "serviceUserPublicKey");
     await clickSubmitButton(this.page);
 });
 

--- a/express/features/update-client.feature
+++ b/express/features/update-client.feature
@@ -14,6 +14,12 @@ Feature: Users can update clients
       Then they should be redirected to a page with the path starting with "/client-details"
       And they should see the text "You have changed your public key"
 
+    Scenario: the user submits a valid public key with headers and junk after the key
+      Given they click on the link with the URL starting with "/change-public-key/"
+      And the user submits a valid public key with headers and junk after the key
+      Then they should be redirected to a page with the path starting with "/client-details"
+      And they should see the text "You have changed your public key"
+
     Scenario: the user submits a valid public key without headers
       Given they click on the link with the URL starting with "/change-public-key/"
       And the user submits a valid public key without headers

--- a/express/src/lib/publicKeyUtils.ts
+++ b/express/src/lib/publicKeyUtils.ts
@@ -6,17 +6,29 @@ export default function getAuthApiCompliantPublicKey(publicKey: string): string 
     publicKey = publicKey.trim();
     // assume PEM with headers
     try {
-        createPublicKey({key: publicKey, format: "pem"});
-        return publicKey.replace(BEGIN, "").replace(END, "").replace(/\n/g, "").replace(/\r/g, "");
+        return makeAuthCompliant(publicKey);
     } catch (ignored) {}
-    // assume they didn't supply headers
-    const publicKeyWithHeaders = `${BEGIN}\n${publicKey}\n${END}\n`;
 
     try {
-        createPublicKey({key: publicKeyWithHeaders, format: "pem"});
-        return publicKeyWithHeaders.replace(BEGIN, "").replace(END, "").replace(/\n/g, "").replace(/\r/g, "");
+        // assume they didn't supply headers
+        const publicKeyWithHeaders = `${BEGIN}\n${publicKey}\n${END}\n`;
+        return makeAuthCompliant(publicKeyWithHeaders);
     } catch (err) {
         console.error(err);
         throw new Error(`Failed to convert\n${publicKey}\n`);
     }
+}
+
+function makeAuthCompliant(publicKey: string): string {
+    const key = createPublicKey({key: publicKey, format: "pem"});
+    return key
+        .export({
+            format: "pem",
+            type: "spki"
+        })
+        .toString()
+        .replace(BEGIN, "")
+        .replace(END, "")
+        .replace(/\n/g, "")
+        .replace(/\r/g, "");
 }

--- a/express/src/middleware/convertPublicKeyForAuth.ts
+++ b/express/src/middleware/convertPublicKeyForAuth.ts
@@ -13,7 +13,7 @@ export function convertPublicKeyForAuth(req: Request, res: Response, next: NextF
             errorMessages: {
                 serviceUserPublicKey: "Enter a valid public key"
             },
-            serviceUserPublicKey: req.query.publicKey
+            serviceUserPublicKey: req.body.authCompliantPublicKey
         });
         return;
     }


### PR DESCRIPTION
Because we just manipulated the input to return and assumed that the crypto lib would refuse to convert input with junk after the key there was a bug.

We would append anythng on a new line after `-----END PUBLIC KEY-----` to the key we rendered and stored.

This changes that so that we export the converted key to PEM format and then strip that so it works for Auth.