### PR TITLE
SSE-2496: Set up a SAM deployment bucket and add permissions to the GHA role

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Run checkov
-        uses: alphagov/di-github-actions/code-quality/run-checkov@0296e8125a9293d4dfd393ebc83785147f5f5927
+        uses: alphagov/di-github-actions/code-quality/run-checkov@57518aaab7352ff25b417b61016e3063cbdd19d4
         with:
           skip-checks: CKV_SECRET_6
 
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Run shell checks
-        uses: alphagov/di-github-actions/code-quality/check-shell-scripts@0296e8125a9293d4dfd393ebc83785147f5f5927
+        uses: alphagov/di-github-actions/code-quality/check-shell-scripts@57518aaab7352ff25b417b61016e3063cbdd19d4
 
   check-linting:
     name: Linting
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check linting and formatting
-        uses: alphagov/di-github-actions/code-quality/check-linting@0296e8125a9293d4dfd393ebc83785147f5f5927
+        uses: alphagov/di-github-actions/code-quality/check-linting@57518aaab7352ff25b417b61016e3063cbdd19d4
 
   check-vulnerabilities:
     name: Vulnerabilities
@@ -44,4 +44,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Run security audit
-        uses: alphagov/di-github-actions/code-quality/run-security-audit@0296e8125a9293d4dfd393ebc83785147f5f5927
+        uses: alphagov/di-github-actions/code-quality/run-security-audit@57518aaab7352ff25b417b61016e3063cbdd19d4

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -36,3 +36,4 @@ jobs:
     uses: ./.github/workflows/run-acceptance-tests.yml
     with:
       host: ${{ needs.deploy-preview-front.outputs.deployment-url }}
+      environment: preview

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -15,7 +15,7 @@ jobs:
     name: Delete app preview
     runs-on: ubuntu-latest
     environment: preview
-    concurrency: deploy-paas-${{ github.head_ref || github.ref_name }}
+    concurrency: deploy-paas-preview-${{ github.head_ref || github.ref_name }}
     steps:
       - name: PaaS login
         uses: alphagov/di-github-actions/paas/log-in-to-paas@57518aaab7352ff25b417b61016e3063cbdd19d4
@@ -50,7 +50,7 @@ jobs:
     name: Delete Fargate deployment
     runs-on: ubuntu-latest
     environment: development
-    concurrency: deploy-fargate-${{ github.head_ref || github.ref_name }}
+    concurrency: deploy-fargate-development-${{ github.head_ref || github.ref_name }}
 
     permissions:
       id-token: write

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -18,7 +18,7 @@ jobs:
     concurrency: deploy-paas-${{ github.head_ref || github.ref_name }}
     steps:
       - name: PaaS login
-        uses: alphagov/di-github-actions/paas/log-in-to-paas@0296e8125a9293d4dfd393ebc83785147f5f5927
+        uses: alphagov/di-github-actions/paas/log-in-to-paas@57518aaab7352ff25b417b61016e3063cbdd19d4
         with:
           cf-org-name: gds-digital-identity-onboarding
           cf-space-name: self-service-preview
@@ -27,7 +27,7 @@ jobs:
 
       - name: Get app name
         if: ${{ github.event_name != 'schedule' }}
-        uses: alphagov/di-github-actions/beautify-branch-name@0296e8125a9293d4dfd393ebc83785147f5f5927
+        uses: alphagov/di-github-actions/beautify-branch-name@57518aaab7352ff25b417b61016e3063cbdd19d4
         with:
           downcase: true
           length-limit: 63
@@ -42,7 +42,7 @@ jobs:
 
       - name: Clean up stale deployments
         if: ${{ github.event_name == 'schedule' }}
-        uses: alphagov/di-github-actions/paas/delete-stale-apps@0296e8125a9293d4dfd393ebc83785147f5f5927
+        uses: alphagov/di-github-actions/paas/delete-stale-apps@57518aaab7352ff25b417b61016e3063cbdd19d4
         with:
           age-threshold-days: 30
 
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Delete docker image
         if: ${{ github.event_name != 'schedule' }}
-        uses: alphagov/di-github-actions/aws/ecr/delete-docker-images@0296e8125a9293d4dfd393ebc83785147f5f5927
+        uses: alphagov/di-github-actions/aws/ecr/delete-docker-images@57518aaab7352ff25b417b61016e3063cbdd19d4
         with:
           aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}
           repository: self-service/frontend
@@ -67,7 +67,7 @@ jobs:
 
       - name: Clean up stale task definitions
         if: ${{ github.event_name == 'schedule' }}
-        uses: alphagov/di-github-actions/aws/ecs/deregister-stale-task-definitions@0296e8125a9293d4dfd393ebc83785147f5f5927
+        uses: alphagov/di-github-actions/aws/ecs/deregister-stale-task-definitions@57518aaab7352ff25b417b61016e3063cbdd19d4
         with:
           aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}
           family: self-service-frontend

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -1,4 +1,5 @@
 name: Deploy branch preview
+run-name: Deploy preview [${{ github.head_ref || github.ref_name }}]
 
 on: workflow_dispatch
 permissions: read-all

--- a/.github/workflows/deploy-to-fargate.yml
+++ b/.github/workflows/deploy-to-fargate.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Push Docker image
         id: push-docker-image
-        uses: alphagov/di-github-actions/aws/ecr/build-docker-image@0296e8125a9293d4dfd393ebc83785147f5f5927
+        uses: alphagov/di-github-actions/aws/ecr/build-docker-image@57518aaab7352ff25b417b61016e3063cbdd19d4
         with:
           repository: self-service/frontend
           image-version: ${{ github.sha }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Register task definition
         id: register-task-definition
-        uses: alphagov/di-github-actions/aws/ecs/register-task-definition@0296e8125a9293d4dfd393ebc83785147f5f5927
+        uses: alphagov/di-github-actions/aws/ecs/register-task-definition@57518aaab7352ff25b417b61016e3063cbdd19d4
         with:
           task-definition: express/task-definition.json
           container: self-service-frontend

--- a/.github/workflows/deploy-to-fargate.yml
+++ b/.github/workflows/deploy-to-fargate.yml
@@ -9,7 +9,7 @@ on:
       ecs-task-role-arn: { required: false }
       ecs-execution-role-arn: { required: false }
 
-concurrency: deploy-fargate-${{ github.head_ref || github.ref_name }}
+concurrency: deploy-fargate-${{ inputs.environment }}-${{ github.head_ref || github.ref_name }}
 
 permissions:
   id-token: write

--- a/.github/workflows/deploy-to-paas.yml
+++ b/.github/workflows/deploy-to-paas.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Push to PaaS
         id: push-to-paas
-        uses: alphagov/di-github-actions/paas/deploy-app@0296e8125a9293d4dfd393ebc83785147f5f5927
+        uses: alphagov/di-github-actions/paas/deploy-app@57518aaab7352ff25b417b61016e3063cbdd19d4
         with:
           url: ${{ inputs.url }}
           manifest: express/manifest.yml

--- a/.github/workflows/deploy-to-paas.yml
+++ b/.github/workflows/deploy-to-paas.yml
@@ -21,7 +21,7 @@ on:
         value: ${{ jobs.deploy.outputs.deployment-url }}
 
 permissions: read-all
-concurrency: deploy-paas-${{ github.head_ref || github.ref_name }}
+concurrency: deploy-paas-${{ inputs.environment }}-${{ github.head_ref || github.ref_name }}
 
 jobs:
   deploy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,3 +35,4 @@ jobs:
     uses: ./.github/workflows/run-acceptance-tests.yml
     with:
       host: ${{ needs.deploy-test-front.outputs.deployment-url }}
+      environment: test

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Report test results
         if: ${{ failure() && steps.run-tests.outcome == 'failure' }}
-        uses: alphagov/di-github-actions/report-step-result/print-file@0296e8125a9293d4dfd393ebc83785147f5f5927
+        uses: alphagov/di-github-actions/report-step-result/print-file@57518aaab7352ff25b417b61016e3063cbdd19d4
         with:
           title: Acceptance tests
           language: shell

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -4,9 +4,10 @@ on:
   workflow_call:
     inputs:
       host: { required: true, type: string }
+      environment: { required: true, type: string }
 
 permissions: read-all
-concurrency: deploy-paas-${{ github.head_ref || github.ref_name }}
+concurrency: deploy-paas-${{ inputs.environment }}-${{ github.head_ref || github.ref_name }}
 
 defaults:
   run:

--- a/infrastructure/api/deploy-sse-api.sh
+++ b/infrastructure/api/deploy-sse-api.sh
@@ -5,9 +5,10 @@ BASE_DIR="$(dirname "${BASH_SOURCE[0]}")"
 pushd "$BASE_DIR" > /dev/null
 
 ../deploy-sam-stack.sh "$@" \
+  --account development \
   --build \
   --template sse-api.yml \
   --base-dir ../.. \
-  --tags StackType=API
+  --tags StackType=Dev Component=API
 
 popd > /dev/null

--- a/infrastructure/check-aws-account.sh
+++ b/infrastructure/check-aws-account.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#Check you're in the correct AWS account
+set -eu
+
+declare -A accounts=(
+  [399055180839]=build
+  [494650018671]=development
+  [325730373996]=staging
+  [663985455444]=integration
+  [389946456390]=production
+)
+
+account_names=$(IFS="|" && echo "${accounts[*]}")
+[[ ${1:-} == "--print-accounts" ]] && echo "${account_names//|/ | }" && exit
+
+target_account="${1:-}"
+if ! actual_account_number=$(aws sts get-caller-identity --query "Account" --output text 2> /dev/null); then
+  echo "Valid AWS credentials were not found in the environment"
+  echo "Authenticate to${target_account:+" the '$target_account' account in"} AWS and try again" >&2
+  exit 255
+fi
+
+actual_account=${accounts[$actual_account_number]:-}
+[[ $actual_account ]] || (echo "Unknown account number: $actual_account_number" >&2 && exit 1)
+
+if ! [[ $target_account ]]; then
+  echo "You're in the '$actual_account' account"
+  exit
+fi
+
+account_regex="\|?$target_account\|?"
+[[ $account_names =~ $account_regex ]] || (echo "Invalid account: '$target_account'" >&2 && exit 1)
+
+if ! [[ $actual_account == "$target_account" ]]; then
+  echo "You should be in '$target_account' but you're in '$actual_account'"
+  echo "Authenticate to the '$target_account' account and try again" >&2
+  exit 1
+fi
+
+echo "✔ You're in the '$target_account' account"

--- a/infrastructure/ci/apply-github-role.sh
+++ b/infrastructure/ci/apply-github-role.sh
@@ -1,17 +1,27 @@
 #!/usr/bin/env bash
 set -eu
 
-PROVIDER_ARN=$(aws iam list-open-id-connect-providers |
-  jq -r '.OpenIDConnectProviderList[].Arn' |
-  grep token.actions.githubusercontent.com || true)
-
 BASE_DIR="$(dirname "${BASH_SOURCE[0]}")"
 pushd "$BASE_DIR" > /dev/null
+../check-aws-account.sh development > /dev/null
+
+PROVIDER_ARN=$(aws iam list-open-id-connect-providers \
+  --query "OpenIDConnectProviderList[?contains(Arn, 'token.actions.githubusercontent.com')].Arn" \
+  --output text)
+
+FRONTEND_STACK=$(aws cloudformation describe-stacks \
+  --stack-name sse-frontend-infrastructure \
+  --query "Stacks[].StackName" \
+  --output text 2> /dev/null)
 
 ../deploy-sam-stack.sh "$@" \
+  --account development \
   --stack-name github-actions-role-sse \
   --template github-actions-role.yml \
   --tags StackType=GitHubActionsRole \
-  --params OIDCProviderArn="$PROVIDER_ARN"
+  --params \
+  OIDCProviderArn="$PROVIDER_ARN" \
+  CreateDeploymentArtifactsBucket=true \
+  FrontendInfrastructureStack="${FRONTEND_STACK:-}"
 
 popd > /dev/null

--- a/infrastructure/ci/github-actions-role.yml
+++ b/infrastructure/ci/github-actions-role.yml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: AWS role to manage DI self-service infrastructure from GitHub Actions
+Description: AWS role and bucket to deploy and manage DI self-service infrastructure from GitHub Actions
 
 Parameters:
   GitHubOrg:
@@ -15,10 +15,18 @@ Parameters:
   AppName:
     Type: String
     Default: self-service
-  InfrastructureStack:
-    Description: Name of the self-service infrastructure SAM stack
+  FrontendInfrastructureStack:
+    Description: Name of the self-service frontend infrastructure stack
     Type: String
-    Default: sse-infrastructure
+  CreateDeploymentArtifactsBucket:
+    Description: Whether to create an S3 bucket for SAM deployments
+    Type: String
+    Default: "false"
+
+Conditions:
+  HasFrontendInfrastructureStack: !Not [ !Equals [ !Ref FrontendInfrastructureStack, "" ] ]
+  CreateDeploymentArtifactsBucket: !Equals [ !Ref CreateDeploymentArtifactsBucket, true ]
+  CreateOIDCProvider: !Equals [ !Ref OIDCProviderArn, "" ]
 
 Resources:
   GitHubRole:
@@ -36,20 +44,17 @@ Resources:
       Policies:
         - PolicyName: GitHubActions
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Resource: "*"
                 Action:
+                  - iam:ListPolicies
                   - ecr:GetAuthorizationToken
                   - ecs:ListTaskDefinitions
                   - ecs:DescribeTaskDefinition
                   - ecs:RegisterTaskDefinition
                   - ecs:DeregisterTaskDefinition
-
-              - Effect: Allow
-                Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/${InfrastructureStack}*
-                Action: iam:PassRole
 
               - Effect: Allow
                 Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AppName}/*
@@ -68,6 +73,34 @@ Resources:
                   - ecr:ListImages
                   - ecr:PutImage
 
+              - !If
+                - HasFrontendInfrastructureStack
+                - Effect: Allow
+                  Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/${FrontendInfrastructureStack}*
+                  Action: iam:PassRole
+                - !Ref AWS::NoValue
+
+  GithubOIDCProvider:
+    Type: AWS::IAM::OIDCProvider
+    Condition: CreateOIDCProvider
+    Properties:
+      Url: https://token.actions.githubusercontent.com
+      ClientIdList: [ sts.amazonaws.com ]
+      ThumbprintList: [ 6938fd4d98bab03faadb97b34396831e3780aea1 ]
+
+  DeploymentArtifactsBucket:
+    # checkov:skip=CKV_AWS_18: "Ensure the S3 bucket has access logging enabled"
+    # checkov:skip=CKV_AWS_21: "Ensure the S3 bucket has versioning enabled"
+    # checkov:skip=CKV_AWS_53: "Ensure S3 bucket has block public ACLS enabled"
+    # checkov:skip=CKV_AWS_54: "Ensure S3 bucket has block public policy enabled"
+    # checkov:skip=CKV_AWS_55: "Ensure S3 bucket has ignore public ACLs enabled"
+    # checkov:skip=CKV_AWS_56: "Ensure S3 bucket has 'restrict_public_bucket' enabled"
+    Type: AWS::S3::Bucket
+    Condition: CreateDeploymentArtifactsBucket
+
 Outputs:
   GitHubRoleARN:
     Value: !GetAtt GitHubRole.Arn
+  DeploymentArtifactsBucket:
+    Condition: CreateDeploymentArtifactsBucket
+    Value: !Ref DeploymentArtifactsBucket

--- a/infrastructure/domains/apply-signin-domains.sh
+++ b/infrastructure/domains/apply-signin-domains.sh
@@ -1,21 +1,16 @@
 #!/usr/bin/env bash
 set -eu
 
-case ${1:-} in
-development | staging | integration | production)
-  ACCOUNT=$1
-  shift
-  ;;
-*)
-  echo "Specify environment (development | staging | integration | production)"
-  exit 1
-  ;;
-esac
-
 BASE_DIR="$(dirname "${BASH_SOURCE[0]}")"
 pushd "$BASE_DIR" > /dev/null
 
-../deploy-sam-stack.sh "$@" \
+if ! [[ ${ACCOUNT:=${1:-}} ]]; then
+  echo "Specify environment ($(../check-aws-account.sh --print-accounts))"
+  exit 1
+fi
+
+../deploy-sam-stack.sh "${@:2}" \
+  --account "$ACCOUNT" \
   --stack-name "$ACCOUNT"-hosted-zone \
   --template "$ACCOUNT"-domains.yml \
   --tags StackType=DNS

--- a/infrastructure/domains/development-domains.yml
+++ b/infrastructure/domains/development-domains.yml
@@ -3,7 +3,7 @@ Transform: AWS::Serverless-2016-10-31
 Description: DNS configuration for self-service development and preview sub domains deployed in the development account
 
 Conditions:
-  IsDevelopmentAccount: !Equals [ !Ref AWS::AccountId, "494650018671" ]
+  IsDevelopmentAccount: !Equals [ !Ref AWS::AccountId, 494650018671 ]
 
 Resources:
   SignInServiceDevelopmentHostedZone:

--- a/infrastructure/domains/integration-domains.yml
+++ b/infrastructure/domains/integration-domains.yml
@@ -3,7 +3,7 @@ Transform: AWS::Serverless-2016-10-31
 Description: DNS configuration for self-service integration domains deployed in the integration account
 
 Conditions:
-  IsIntegrationAccount: !Equals [ !Ref AWS::AccountId, "663985455444" ]
+  IsIntegrationAccount: !Equals [ !Ref AWS::AccountId, 663985455444 ]
 
 Resources:
   SignInServiceIntegrationHostedZone:

--- a/infrastructure/domains/production-domains.yml
+++ b/infrastructure/domains/production-domains.yml
@@ -3,7 +3,7 @@ Transform: AWS::Serverless-2016-10-31
 Description: DNS configuration for self-service production
 
 Conditions:
-  IsProductionAccount: !Equals [ !Ref AWS::AccountId, "389946456390" ]
+  IsProductionAccount: !Equals [ !Ref AWS::AccountId, 389946456390 ]
 
 Resources:
   # The production nameservers are used by GOV.UK to direct traffic for sign-in and all subdomains to our hosted zone

--- a/infrastructure/domains/staging-domains.yml
+++ b/infrastructure/domains/staging-domains.yml
@@ -3,7 +3,7 @@ Transform: AWS::Serverless-2016-10-31
 Description: DNS configuration for self-service staging domains deployed in the staging account
 
 Conditions:
-  IsStagingAccount: !Equals [ !Ref AWS::AccountId, "325730373996" ]
+  IsStagingAccount: !Equals [ !Ref AWS::AccountId, 325730373996 ]
 
 Resources:
   SignInServiceStagingHostedZone:

--- a/infrastructure/frontend/apply-frontend-infrastructure.sh
+++ b/infrastructure/frontend/apply-frontend-infrastructure.sh
@@ -4,6 +4,7 @@ set -eu
 BASE_DIR="$(dirname "${BASH_SOURCE[0]}")"
 
 "$BASE_DIR"/../deploy-sam-stack.sh "$@" \
+  --account development \
   --stack-name sse-frontend-infrastructure \
   --template "$BASE_DIR"/sse-frontend-infrastructure.yml \
   --tags StackType=FrontendInfrastructure

--- a/infrastructure/frontend/sse-frontend-infrastructure.yml
+++ b/infrastructure/frontend/sse-frontend-infrastructure.yml
@@ -8,7 +8,7 @@ Parameters:
     Default: self-service
 
 Conditions:
-  IsDevelopmentAccount: !Equals [ !Ref AWS::AccountId, "494650018671" ]
+  IsDevelopmentAccount: !Equals [ !Ref AWS::AccountId, 494650018671 ]
 
 Resources:
   FrontendECRRepository:


### PR DESCRIPTION
**Add a deployment bucket and additional permissions to the GitHub Actions role**

More permissions are needed to deploy the API lambdas.
A SAM deployment bucket needs to be set up in the account before deployments can be done.

Add a check for the frontend infra stack and the OIDC provider, as the template will need to be used in different envs with different requirements.

_Ignore a bunch of checkov warnings for now - we will deal with them later._

---

- Set concurrency for deployments based on the environment
  Avoid unnecessary blocking of deployments in different environments.

- Move the logic to check the authenticated AWS account to a separate script
  Encapsulate the logic in one script and reuse in deployment scripts.

- Use boolean vars when deploying SAM stacks so they can be picked up from the user's terminal environment, if set or exported