### PR TITLE
removing team members for MVP

### DIFF
--- a/express/src/views/service-details/layout-service-details.njk
+++ b/express/src/views/service-details/layout-service-details.njk
@@ -34,9 +34,6 @@
             <li class="side-navigation__item{% if sidebarActiveItem == 'client-details' %} side-navigation__item--active{% endif %}">
               <a class="govuk-link govuk-link--no-visited-state" href="/client-details/{{ serviceId }}">Client details</a>
             </li>
-            <li class="side-navigation__item{% if sidebarActiveItem == 'team-members' %} side-navigation__item--active{% endif %}">
-              <a class="govuk-link govuk-link--no-visited-state" href="/team-members/{{ serviceId }}/{{ selfServiceClientId }}/{{ clientId }}">Team members</a>
-            </li>
             <li class="side-navigation__item{% if sidebarActiveItem == 'private-beta' %} side-navigation__item--active{% endif %}">
               <a class="govuk-link govuk-link--no-visited-state" href="/private-beta/{{ serviceId }}/{{ selfServiceClientId }}/{{ clientId }}">
                 Joining private beta


### PR DESCRIPTION
- Removed the "Team members" link from client details page. It is not needed for MVP.