### PR TITLE
SSE-2467 template changes for devplatform

### DIFF
--- a/infrastructure/api/sse-api.yml
+++ b/infrastructure/api/sse-api.yml
@@ -15,6 +15,39 @@ Parameters:
     Type: String
     Default: not-a-real-email-address@fake.com
     Description: Email address for private beta request notifications.
+  PermissionsBoundary:
+    Description: "The ARN of the permissions boundary to apply when creating IAM roles"
+    Type: String
+    Default: "none"
+  CodeSigningConfigArn:
+    Type: String
+    Description: >
+      The ARN of the Code Signing Config to use, provided by the deployment pipeline
+    Default: "none"
+
+Conditions:
+  UsePermissionsBoundary:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref PermissionsBoundary
+          - "none"
+  UseCodeSigning:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref CodeSigningConfigArn
+          - "none"
+
+Globals:
+  Function:
+    CodeSigningConfigArn: !If
+      - UseCodeSigning
+      - !Ref CodeSigningConfigArn
+      - !Ref AWS::NoValue
+    PermissionsBoundary: !If
+      - UsePermissionsBoundary
+      - !Ref PermissionsBoundary
+      - !Ref AWS::NoValue
+
 
 Resources:
 
@@ -443,6 +476,10 @@ Resources:
   StepFunctionExecutionRole:
     Type: AWS::IAM::Role
     Properties:
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:


### PR DESCRIPTION
Deploying stacks with devplatform requires two extra parameters:

*	`PermissionsBoundary`
*	`CodeSigningConfigArn`

These parameter values are supplied by the secure pipeline deployers and are not applied (`AWS::NoValue`) if the parameter is not passed in.

They need to be added to all Lambdas as they create impicit roles and and custom roles that are created like our `StepFunctionExecutionRole`.  I've used Global for the lambdas but global cannot be used for roles.