### PR TITLE
SSE-2553: Bugfix Post logout redirect URIs

### DIFF
--- a/express/src/lib/clientUtils.ts
+++ b/express/src/lib/clientUtils.ts
@@ -8,7 +8,7 @@ export function dynamoClientToDomainClient(client: ClientFromDynamo): Client {
         clientName: client.client_name,
         contacts: client.contacts,
         defaultFields: client.default_fields,
-        postLogoutUris: client.post_logout_redirect_uris,
+        postLogoutUris: client.post_logout_redirect_uris || [],
         publicKey: client.public_key,
         redirectUris: client.redirect_uris,
         scopes: client.scopes,


### PR DESCRIPTION
Post logout redirect URIs became optional and as a result an empty database will not supply a value for them meaning clients can't be displayed because the frontend tries to do `.split(" ")` on an `undefined` value.

This ensures that if `client.post_logout_redirect_uris` are not returned, an empty array is returned instead.