### PR TITLE
SSE-2488: Make usage of the password field consistent

### DIFF
--- a/express/src/views/account/change-password.njk
+++ b/express/src/views/account/change-password.njk
@@ -10,8 +10,8 @@
 {% endblock %}
 
 {% block formInputs %}
-  {{ form.passwordInput("Current password", "currentPassword", autocomplete = "current-password") }}
-  {{ form.passwordInput("Enter a new password", hint = "Must be at least 8 characters") }}
+  {{ form.passwordInput("Current password", "currentPassword") }}
+  {{ form.passwordInput("Enter a new password", hint = "Must be at least 8 characters", autocomplete = "new-password") }}
 {% endblock %}
 
 {% block scripts %}

--- a/express/src/views/common/enter-app-code.njk
+++ b/express/src/views/common/enter-app-code.njk
@@ -5,12 +5,11 @@
 
 {% block formInputs %}
   {{ form.securityCodeInput(
-    "Enter the 6 digit security code from your authenticator app",
-    "govuk-label--l",
-    true
+    "Enter the 6 digit security code from your authenticator app", "govuk-label--l", isPageHeading = true
   ) }}
 {% endblock %}
 
 {% block afterForm %}
-  <p class="govuk-body">If you cannot get your security code, contact us using our <a class="govuk-link" href="https://www.sign-in.service.gov.uk/contact-us">support form</a>.</p>
+  <p class="govuk-body">If you cannot get your security code, contact us using our
+    <a class="govuk-link" href="https://www.sign-in.service.gov.uk/contact-us">support form</a>.</p>
 {% endblock %}

--- a/express/src/views/create-account/choose-security-codes.njk
+++ b/express/src/views/create-account/choose-security-codes.njk
@@ -23,5 +23,3 @@
       }
     ], isPageHeading = true) }}
 {% endblock %}
-
-

--- a/express/src/views/create-account/existing-account.njk
+++ b/express/src/views/create-account/existing-account.njk
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block formInputs %}
-  {{ form.passwordInput("Enter your password", autocomplete = "current-password") }}
+  {{ form.passwordInput("Enter your password") }}
 {% endblock %}
 
 {% block afterForm %}

--- a/express/src/views/create-account/new-password.njk
+++ b/express/src/views/create-account/new-password.njk
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block formInputs %}
-  {{ form.passwordInput(hint = "Must be at least 8 characters") }}
+  {{ form.passwordInput(hint = "Must be at least 8 characters", autocomplete = "new-password") }}
 {% endblock %}
 
 {% block scripts %}

--- a/express/src/views/create-new-password.njk
+++ b/express/src/views/create-new-password.njk
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block formInputs %}
-  {{ form.passwordInput(hint = "Must be at least 8 characters. Do not use very common passwords, like ‘password’.") }}
+  {{ form.passwordInput(hint = "Must be at least 8 characters. Do not use very common passwords, like ‘password’.", autocomplete = "new-password") }}
   {{ form.hiddenInput("userName", userName) }}
   {{ form.hiddenInput("confirmationCode", confirmationCode) }}
 {% endblock %}

--- a/express/src/views/macros/form-inputs.njk
+++ b/express/src/views/macros/form-inputs.njk
@@ -51,7 +51,7 @@
   {{ textInput(label | default("Email address"), "emailAddress", classes, hint, "email", "email") }}
 {% endmacro %}
 
-{% macro passwordInput(label, id, hint, autocomplete = "new-password") %}
+{% macro passwordInput(label, id, hint, autocomplete = "current-password") %}
   <div class="gem-c-show-password" data-module="show-password" data-disable-form-submit-check="false"
        data-show-text="Show" data-hide-text="Hide" data-show-full-text="Show password"
        data-hide-full-text="Hide password" data-announce-show="Your password is shown"

--- a/express/src/views/sign-in-enter-password.njk
+++ b/express/src/views/sign-in-enter-password.njk
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block formInputs %}
-  {{ form.passwordInput("Password", autocomplete = "current-password") }}
+  {{ form.passwordInput("Password") }}
 {% endblock %}
 
 {% block afterForm %}


### PR DESCRIPTION
Make the field autocomplete as a current password by default, and override for new password fields.

Use the param names for the args in the security code input for clarity.