### PR TITLE
SSE-2565 Change email sending to DEVELOPER

### DIFF
--- a/backend/cognito/template.yaml
+++ b/backend/cognito/template.yaml
@@ -11,7 +11,9 @@ Parameters:
   SignInHostedZone:
     Type: String
     Description: Deployment specific SignInHostedZone
-
+  ExternalId:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /self-service/config/cognito/external-id
 Resources:
   DomainIdentityForSES:
     Type: AWS::SES::EmailIdentity
@@ -19,8 +21,6 @@ Resources:
       EmailIdentity: !Ref DomainOrEmailIdentityToVerify
 
   DevelopmentEmailIdentityRoute53Records:
-    DependsOn:
-      - DomainIdentityForSES
     Type: AWS::Route53::RecordSetGroup
     Properties:
       Comment: "Records created to verify domain ownership with SES"
@@ -63,10 +63,10 @@ Resources:
             Resource: !Sub arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/${DomainOrEmailIdentityToVerify}
             Condition:
               StringEquals:
-                "ses:FromAddress": !Sub 'sign-in@${DomainOrEmailIdentityToVerify}'
+                "ses:FromAddress": !Sub 'admin-tool@${DomainOrEmailIdentityToVerify}'
       Environment:
         Variables:
-          FROM_EMAIL_ADDRESS: !Sub 'sign-in@${DomainOrEmailIdentityToVerify}'
+          FROM_EMAIL_ADDRESS: !Sub 'admin-tool@${DomainOrEmailIdentityToVerify}'
 
 
       Handler: src/handlers/confirm-forgot-password-message.handler
@@ -124,7 +124,6 @@ Resources:
 
   UserPool:
     Type: AWS::Cognito::UserPool
-    DependsOn: SmsRole
     Properties:
       Policies:
         PasswordPolicy:
@@ -442,9 +441,10 @@ Resources:
       EmailConfiguration:
         EmailSendingAccount: DEVELOPER
         SourceArn: !Sub arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/${DomainOrEmailIdentityToVerify}
-        From: !Sub 'sign-in@${DomainOrEmailIdentityToVerify}'
+        From: !Sub 'admin-tool@${DomainOrEmailIdentityToVerify}'
       SmsConfiguration:
         SnsCallerArn: !GetAtt SmsRole.Arn
+        ExternalId: !Ref ExternalId
         SnsRegion: eu-west-2
       UserPoolTags: { }
       AdminCreateUserConfig:
@@ -599,7 +599,6 @@ Resources:
 
   Client:
     Type: AWS::Cognito::UserPoolClient
-    DependsOn: UserPool
     Properties:
       UserPoolId: !Ref UserPool
       ExplicitAuthFlows:
@@ -615,6 +614,9 @@ Resources:
           - Effect: "Allow"
             Principal:
               Service: "cognito-idp.amazonaws.com"
+            Condition:
+              StringEquals:
+                "sts:ExternalId": !Ref ExternalId
             Action: "sts:AssumeRole"
       Policies:
         - PolicyName: !Sub "${AWS::StackName}-SnsPublishPolicy"

--- a/backend/cognito/template.yaml
+++ b/backend/cognito/template.yaml
@@ -440,7 +440,9 @@ Resources:
       SmsAuthenticationMessage: '{####} is your GOV.UK One Login security code.'
       MfaConfiguration: OPTIONAL
       EmailConfiguration:
-        EmailSendingAccount: COGNITO_DEFAULT
+        EmailSendingAccount: DEVELOPER
+        SourceArn: !Sub arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/${DomainOrEmailIdentityToVerify}
+        From: !Sub 'sign-in@${DomainOrEmailIdentityToVerify}'
       SmsConfiguration:
         SnsCallerArn: !GetAtt SmsRole.Arn
         SnsRegion: eu-west-2


### PR DESCRIPTION
The verification email should have the EmailSendingAccount set to DEVELOPER with the required properties instead of COGNITO_DEFAULT which doesn't use our email address and has a daily limit on the number of emails that can be sent.