### PR TITLE
BAU: Use latest TypeScript libraries

### DIFF
--- a/acceptance-tests/support/steps/shared-steps.ts
+++ b/acceptance-tests/support/steps/shared-steps.ts
@@ -30,7 +30,7 @@ When("they click on the {string} link", async function (text: string) {
 
 When("they click on the {string} external link", async function (text: string) {
     const link = await getLink(this.page, text);
-    await clickElement(this.page, link, 10000);
+    await clickElement(this.page, link, 50000);
 });
 
 When("they click on the {string} link that opens in a new tab", async function (this: TestContext, linkText: string) {

--- a/acceptance-tests/support/test-setup.ts
+++ b/acceptance-tests/support/test-setup.ts
@@ -32,16 +32,16 @@ export class TestContext extends World {
 }
 
 BeforeAll(async function () {
-    console.log(`Running tests against ${process.env.HOST || "local"}`);
+    console.log(`Running tests against ${process.env.HOST ?? "local"}`);
     browser = await puppeteer.launch({headless: !process.env.SHOW_BROWSER});
 });
 
-Before(async function () {
-    this.host = (process.env.HOST as string) || "http://localhost:3000";
+Before(async function (this: TestContext) {
+    this.host = process.env.HOST ?? "http://localhost:3000";
     this.page = await browser.newPage();
 });
 
-After(async function () {
+After(async function (this: TestContext) {
     if (!process.env.SHOW_BROWSER) {
         await this.page.close();
     }

--- a/acceptance-tests/tsconfig.json
+++ b/acceptance-tests/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "lib": ["DOM"],
-    "rootDir": "./support"
+    "rootDir": "./support",
+    "noEmit": true
   },
   "include": ["support/**/*"]
 }

--- a/backend/api/src/dynamodb-client.ts
+++ b/backend/api/src/dynamodb-client.ts
@@ -137,7 +137,7 @@ class DynamoDbClient {
     }
 
     private getAttributeNameAlias(attributeName: string) {
-        return DynamoDbClient.KEYWORD_SUBSTITUTES[attributeName] || `#${attributeName}`;
+        return DynamoDbClient.KEYWORD_SUBSTITUTES[attributeName] ?? `#${attributeName}`;
     }
 
     private getAttributeValueLabel(attributeName: string) {

--- a/backend/api/tsconfig.json
+++ b/backend/api/tsconfig.json
@@ -3,6 +3,5 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.test.ts"]
+  "include": ["src/**/*"]
 }

--- a/express/assets/javascripts/cookies.js
+++ b/express/assets/javascripts/cookies.js
@@ -196,6 +196,6 @@ const cookieBanner = function () {
 };
 
 if (window) {
-    window.GOVUKSignIn = window.GOVUKSignIn || {};
+    window.GOVUKSignIn = window.GOVUKSignIn ?? {};
     window.GOVUKSignIn.CookieBanner = cookieBanner();
 }

--- a/express/src/app.ts
+++ b/express/src/app.ts
@@ -19,13 +19,13 @@ import "./types/session";
 
 const app = Express();
 
-const cognitoPromise = import(`./services/cognito/${process.env.COGNITO_CLIENT || "CognitoClient"}`).then(client => {
+const cognitoPromise = import(`./services/cognito/${process.env.COGNITO_CLIENT ?? "CognitoClient"}`).then(client => {
     const cognito = new client.default.CognitoClient();
     app.set("cognitoClient", cognito);
     return cognito;
 });
 
-const lambdaPromise = import(`./services/lambda-facade/${process.env.LAMBDA_FACADE || "LambdaFacade"}`).then(facade => {
+const lambdaPromise = import(`./services/lambda-facade/${process.env.LAMBDA_FACADE ?? "LambdaFacade"}`).then(facade => {
     const lambda = facade.lambdaFacadeInstance;
     app.set("lambdaFacade", facade.lambdaFacadeInstance);
     return lambda;
@@ -58,5 +58,5 @@ app.use(errorHandler);
 
 app.locals.googleTagId = process.env.GOOGLE_TAG_ID;
 
-const port = process.env.PORT || 3000;
+const port = process.env.PORT ?? 3000;
 app.listen(port, () => console.log(`Server running; listening on port ${port}`));

--- a/express/src/config/session-storage.ts
+++ b/express/src/config/session-storage.ts
@@ -9,9 +9,9 @@ function getSessionStorage(): RequestHandler {
     if (process.env.SESSION_STORAGE === "DynamoDB") {
         const table = process.env.SESSIONS_TABLE;
         const endpoint = process.env.DYNAMO_DB_ENDPOINT;
-        const region = process.env.AWS_REGION || "eu-west-2";
+        const region = process.env.AWS_REGION ?? "eu-west-2";
         const client = new DynamoDB({region: region, endpoint: endpoint});
-        console.log(`Using dynamoDB session storage | Table: ${table} | Endpoint: ${endpoint || "AWS"}`);
+        console.log(`Using dynamoDB session storage | Table: ${table} | Endpoint: ${endpoint ?? "AWS"}`);
 
         const options = {
             table: table,

--- a/express/src/lib/AuthenticationResultParser.ts
+++ b/express/src/lib/AuthenticationResultParser.ts
@@ -12,7 +12,7 @@ export default class AuthenticationResultParser {
 
     static getCognitoId(authenticationResult: AuthenticationResultType): string {
         const claims = this.getIdClaims(authenticationResult);
-        return claims["cognito:username"] || claims["sub"];
+        return claims["cognito:username"] ?? claims["sub"];
     }
 
     static getPhoneNumber(authenticationResult: AuthenticationResultType): string {

--- a/express/src/lib/clientUtils.ts
+++ b/express/src/lib/clientUtils.ts
@@ -8,7 +8,7 @@ export function dynamoClientToDomainClient(client: ClientFromDynamo): Client {
         clientName: client.client_name,
         contacts: client.contacts,
         defaultFields: client.default_fields,
-        postLogoutUris: client.post_logout_redirect_uris || [],
+        postLogoutUris: client.post_logout_redirect_uris ?? [],
         publicKey: client.public_key,
         redirectUris: client.redirect_uris,
         scopes: client.scopes,

--- a/express/src/lib/validators/urisValidator.ts
+++ b/express/src/lib/validators/urisValidator.ts
@@ -38,5 +38,5 @@ function findInvalidUrls(urls: string[]): string[] {
 }
 
 function isValidLocalHost(url: URL): boolean {
-    return url.hostname === "localhost" && (url.protocol === "http:" || url.protocol === "https:");
+    return url.hostname === "localhost" && (url.protocol === "http:" ?? url.protocol === "https:");
 }

--- a/express/src/middleware/request-context.ts
+++ b/express/src/middleware/request-context.ts
@@ -5,7 +5,7 @@ export default setRequestContext();
 
 export function setRequestContext(property?: ContextProperty): RequestParamHandler {
     return (req, res, next, value, name) => {
-        req.context[property || (name as ContextProperty)] = value;
+        req.context[property ?? (name as ContextProperty)] = value;
         next();
     };
 }

--- a/express/src/middleware/request-context.ts
+++ b/express/src/middleware/request-context.ts
@@ -1,4 +1,5 @@
-import {ContextProperty, RequestParamHandler} from "../types/request";
+import {RequestParamHandler} from "express";
+import {ContextProperty} from "../types/request";
 
 export default setRequestContext();
 

--- a/express/src/middleware/validators/mobileOtpValidator.ts
+++ b/express/src/middleware/validators/mobileOtpValidator.ts
@@ -32,9 +32,5 @@ export function mobileSecurityCodeValidator(textMessageNotReceivedUrl: string, h
 }
 
 function getMobileNumber(req: Request): string {
-    if (req.session?.mfaResponse?.codeSentTo) {
-        return req.session.mfaResponse.codeSentTo;
-    } else {
-        return (req.session.enteredMobileNumber as string) || (req.session.mobileNumber as string);
-    }
+    return nonNull(req.session.mfaResponse?.codeSentTo ?? req.session.enteredMobileNumber ?? req.session.mobileNumber);
 }

--- a/express/src/services/cognito/StubCognitoClient.ts
+++ b/express/src/services/cognito/StubCognitoClient.ts
@@ -130,17 +130,17 @@ export class CognitoClient implements CognitoInterface {
 
     async createUser(email: string): Promise<AdminCreateUserCommandOutput> {
         const returnValue = await this.getOverriddenReturnValue("createUser", "email", email);
-        return Promise.resolve(returnValue || {$metadata: {}});
+        return Promise.resolve(returnValue ?? {$metadata: {}});
     }
 
     async resendEmailAuthCode(email: string): Promise<AdminCreateUserCommandOutput> {
         const returnValue = await this.getOverriddenReturnValue("login", "email", email);
-        return Promise.resolve(returnValue || {$metadata: {}});
+        return Promise.resolve(returnValue ?? {$metadata: {}});
     }
 
     async login(email: string, password: string): Promise<AdminInitiateAuthCommandOutput> {
         const returnValue = await this.getOverriddenReturnValue("login", "email", email);
-        return Promise.resolve(returnValue || {$metadata: {}});
+        return Promise.resolve(returnValue ?? {$metadata: {}});
     }
 
     sendMobileNumberVerificationCode(accessToken: string): Promise<GetUserAttributeVerificationCodeCommandOutput> {
@@ -161,7 +161,7 @@ export class CognitoClient implements CognitoInterface {
 
     async setNewPassword(email: string, password: string, session: string): Promise<RespondToAuthChallengeCommandOutput> {
         const returnValue = await this.getOverriddenReturnValue("setNewPassword", "password", password);
-        return Promise.resolve(returnValue || {$metadata: {}});
+        return Promise.resolve(returnValue ?? {$metadata: {}});
     }
 
     changePassword(accessToken: string, previousPassword: string, proposedPassword: string): Promise<ChangePasswordCommandOutput> {
@@ -175,7 +175,7 @@ export class CognitoClient implements CognitoInterface {
 
     async verifyMobileUsingSmsCode(accessToken: string, code: string): Promise<VerifyUserAttributeCommandOutput> {
         const returnValue = await this.getOverriddenReturnValue("verifySmsCode", "code", code);
-        return Promise.resolve(returnValue || {$metadata: {}});
+        return Promise.resolve(returnValue ?? {$metadata: {}});
     }
 
     setMfaPreference(cognitoUsername: string): Promise<AdminSetUserMFAPreferenceCommandOutput> {
@@ -193,7 +193,7 @@ export class CognitoClient implements CognitoInterface {
             throw this.getException(override.throw);
         }
 
-        return {...override.return, $metadata: override.return?.$metadata || {}};
+        return {...override.return, $metadata: override.return?.$metadata ?? {}};
     }
 
     private async getOverrideFor(method: string, parameter: string, value: string): Promise<Override | undefined> {
@@ -229,7 +229,7 @@ export class CognitoClient implements CognitoInterface {
 
     async respondToMfaChallenge(username: string, mfaCode: string, session: string): Promise<AdminRespondToAuthChallengeCommandOutput> {
         const returnValue = await this.getOverriddenReturnValue("respondToMfaChallenge", "username", username);
-        return Promise.resolve(returnValue || {$metadata: {}});
+        return Promise.resolve(returnValue ?? {$metadata: {}});
     }
 
     setMobilePhoneAsVerified(username: string): Promise<AdminUpdateUserAttributesCommandOutput> {

--- a/express/src/services/self-service-services-service.ts
+++ b/express/src/services/self-service-services-service.ts
@@ -164,7 +164,7 @@ export default class SelfServiceServicesService {
     async listClients(serviceId: string, accessToken: string): Promise<Client[]> {
         return this.lambda
             .listClients(serviceId, accessToken)
-            .then(results => results.data.Items?.map(client => dynamoClientToDomainClient(unmarshall(client) as ClientFromDynamo)) || []);
+            .then(results => results.data.Items?.map(client => dynamoClientToDomainClient(unmarshall(client) as ClientFromDynamo)) ?? []);
     }
 }
 

--- a/express/src/types/request.d.ts
+++ b/express/src/types/request.d.ts
@@ -1,18 +1,12 @@
-import express, {NextFunction, Response} from "express";
+export type ContextProperty = keyof RequestContext;
 
 declare global {
     namespace Express {
         interface Request {
-            context: Partial<Record<ContextProperty, string>>;
+            context: Partial<RequestContext>;
         }
     }
 }
-
-export interface RequestParamHandler extends express.RequestParamHandler {
-    (req: express.Request, res: Response, next: NextFunction, value: string, name: ContextProperty): void;
-}
-
-export type ContextProperty = keyof RequestContext;
 
 interface RequestContext {
     serviceId: string;

--- a/express/tests/middleware/validators/mobileOtpValidator.test.ts
+++ b/express/tests/middleware/validators/mobileOtpValidator.test.ts
@@ -1,5 +1,6 @@
 import {NextFunction, Request, Response} from "express";
 import {Session, SessionData} from "express-session";
+import "../../../src/lib/utils/optional";
 import {mobileSecurityCodeValidator} from "../../../src/middleware/validators/mobileOtpValidator";
 import "../../../src/types/session";
 

--- a/express/tsconfig.json
+++ b/express/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/views/**/*"]
 }

--- a/infrastructure/api/deploy-sse-api.sh
+++ b/infrastructure/api/deploy-sse-api.sh
@@ -4,14 +4,14 @@ set -eu
 BASE_DIR="$(dirname "${BASH_SOURCE[0]}")"
 pushd "$BASE_DIR" > /dev/null
 
-[[ $(aws sts get-caller-identity --query "Arn") =~ assumed-role\/([a-zA-z.]+) ]] && user_name=${BASH_REMATCH[1]}
+[[ $(aws sts get-caller-identity --query "Arn" 2> /dev/null) =~ assumed-role\/([a-zA-z.]+) ]] && user_name=${BASH_REMATCH[1]}
 
 ../deploy-sam-stack.sh "$@" \
   --build \
   --base-dir ../.. \
   --account development \
   --template sse-api.yml \
-  --tags sse:component=api sse:stack-type=dev sse:stack-role=application sse:owner="$user_name" \
+  --tags sse:component=api sse:stack-type=dev sse:stack-role=application sse:owner="${user_name:-}" \
   --params LogGroupNamePrefix=/self-service/dev
 
 popd > /dev/null

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,16 @@
 {
   "compilerOptions": {
-    "lib": ["es2020"],
-    "module": "commonjs",
-    "target": "es2020",
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "CommonJS",
     "strict": true,
     "sourceMap": true,
-    "esModuleInterop": true,
     "skipLibCheck": true,
+    "esModuleInterop": true,
+    "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
+    "allowUnreachableCode": false,
+    "moduleResolution": "Node",
     "removeComments": true,
     "noUnusedLocals": true,
     "baseUrl": "./"


### PR DESCRIPTION
**Use the latest TypeScript libraries**

Use ES2022 instead of ES2020 to get the latest features and APIs.
Update TypeScript config to include more compiler checks.

---

**Use the nullish coalescing operator**

Use the nullish coalescing operator instead of the boolean `OR` when dealing with null or undefined values to provide a default value. The boolean `||` operator should only be used in boolean logic to evaluate an expression to `true` or `false`. Use the `??` operator to provide a value when a variable is null or undefined, or `??=` to assign a default value.

---

- Extend timeout for external links in acceptance tests to reduce flaky fails
- Fix optional value handling in the API script
- Simplify request context types; remove unnecessary custom handler