### PR TITLE
BAU: Update validators

### DIFF
--- a/express/src/lib/commonPasswords/commonPasswordsSingleton.ts
+++ b/express/src/lib/commonPasswords/commonPasswordsSingleton.ts
@@ -1,3 +1,0 @@
-import {CommonPasswords} from "./CommonPasswords";
-
-export default CommonPasswords.loadCommonPasswords();

--- a/express/src/lib/validators/allowed-email-domains.ts
+++ b/express/src/lib/validators/allowed-email-domains.ts
@@ -1,0 +1,20 @@
+import {readFile} from "fs/promises";
+import {resources} from "../../config/resources";
+
+const allowedEmailDomains = loadAllowedEmailDomains();
+
+export default async function hasAllowedDomain(emailAddress: string): Promise<boolean> {
+    const domains = await allowedEmailDomains;
+    const emailDomain = getEmailDomain(emailAddress);
+    return domains.some(domain => emailDomain.endsWith(domain));
+}
+
+function getEmailDomain(email: string) {
+    return email.split("@")[1];
+}
+
+async function loadAllowedEmailDomains() {
+    console.log("Loading allowed email domains....");
+    const domains = await readFile(resources.validDomains, {encoding: "utf8"});
+    return domains.trim().split("\n");
+}

--- a/express/src/lib/validators/checkOtp.ts
+++ b/express/src/lib/validators/checkOtp.ts
@@ -1,29 +1,21 @@
 import {validationResult} from "./validationResult";
 
-export function validateSecurityCode(securityCode: string): validationResult {
-    if (isEmpty(securityCode)) {
+export default function validateSecurityCode(securityCode: string): validationResult {
+    if (!securityCode) {
         return {isValid: false, errorMessage: "Enter the 6 digit security code"};
     }
 
-    if (notSixCharacters(securityCode)) {
+    if (securityCode.length != 6) {
         return {isValid: false, errorMessage: "Enter the security code using only 6 digits"};
     }
 
-    if (notJustDigits(securityCode)) {
+    if (!hasOnlyDigits(securityCode)) {
         return {isValid: false, errorMessage: "Your security code should only include numbers"};
     }
 
     return {isValid: true};
 }
 
-function isEmpty(securityCode: string): boolean {
-    return securityCode === "";
-}
-
-function notSixCharacters(securityCode: string): boolean {
-    return !/^.{6}$/.test(securityCode);
-}
-
-function notJustDigits(securityCode: string): boolean {
-    return !/^[0-9]{6}$/.test(securityCode);
+function hasOnlyDigits(securityCode: string): boolean {
+    return !/\D/.test(securityCode);
 }

--- a/express/src/lib/validators/emailValidator.ts
+++ b/express/src/lib/validators/emailValidator.ts
@@ -1,9 +1,9 @@
-import allowedEmailDomains from "../allowedEmailDomains";
 import isRfc822Compliant from "../rfc822-validate";
+import hasAllowedDomain from "./allowed-email-domains";
 import {validationResult} from "./validationResult";
 
-export async function validateEmail(emailAddress: string): Promise<validationResult> {
-    if (emailAddress === "") {
+export default async function validateEmail(emailAddress: string): Promise<validationResult> {
+    if (!emailAddress) {
         return {isValid: false, errorMessage: "Enter your email address"};
     }
 
@@ -11,13 +11,11 @@ export async function validateEmail(emailAddress: string): Promise<validationRes
         return {isValid: false, errorMessage: "Enter an email address in the correct format, like name@example.com"};
     }
 
-    if (!(await isAllowedDomain(emailAddress))) {
+    const isAllowed = await hasAllowedDomain(emailAddress);
+
+    if (!isAllowed) {
         return {isValid: false, errorMessage: "Enter a government email address"};
     }
 
     return {isValid: true};
-}
-
-async function isAllowedDomain(emailAddress: string): Promise<boolean> {
-    return (await allowedEmailDomains).some(domain => emailAddress.endsWith(domain));
 }

--- a/express/src/lib/validators/password-validator.ts
+++ b/express/src/lib/validators/password-validator.ts
@@ -1,11 +1,13 @@
 import {validationResult} from "./validationResult";
 
-export function validatePassword(password: string): validationResult {
+export default function validatePassword(password: string): validationResult {
     if (password.length === 0) {
         return {isValid: false, errorMessage: "Enter a password"};
     }
+
     if (password.length < 8) {
         return {isValid: false, errorMessage: "Your password must be 8 characters or more"};
     }
+
     return {isValid: true};
 }

--- a/express/src/lib/validators/uris-validator.ts
+++ b/express/src/lib/validators/uris-validator.ts
@@ -1,6 +1,6 @@
 import {validationResult} from "./validationResult";
 
-export function validateUris(urls: string[]): validationResult {
+export default function validateUris(urls: string[]): validationResult {
     if (urls.length === 0) {
         return {isValid: false, errorMessage: "Enter your redirect URIs"};
     }

--- a/express/src/middleware/validators/emailOtpValidator.ts
+++ b/express/src/middleware/validators/emailOtpValidator.ts
@@ -1,5 +1,5 @@
 import {NextFunction, Request, Response} from "express";
-import {validateSecurityCode} from "../../lib/validators/checkOtp";
+import validateSecurityCode from "../../lib/validators/checkOtp";
 import {validationResult} from "../../lib/validators/validationResult";
 
 export async function emailSecurityCodeValidator(req: Request, res: Response, next: NextFunction) {

--- a/express/src/middleware/validators/emailValidator.ts
+++ b/express/src/middleware/validators/emailValidator.ts
@@ -1,5 +1,5 @@
 import {RequestHandler} from "express";
-import {validateEmail} from "../../lib/validators/emailValidator";
+import validateEmail from "../../lib/validators/emailValidator";
 import {validationResult} from "../../lib/validators/validationResult";
 
 export function emailValidator(template: string): RequestHandler {

--- a/express/src/middleware/validators/mobileOtpValidator.ts
+++ b/express/src/middleware/validators/mobileOtpValidator.ts
@@ -1,6 +1,6 @@
 import {Request, RequestHandler} from "express";
 import {obscureNumber} from "../../lib/mobileNumberUtils";
-import {validateSecurityCode} from "../../lib/validators/checkOtp";
+import validateSecurityCode from "../../lib/validators/checkOtp";
 
 export function mobileSecurityCodeValidator(textMessageNotReceivedUrl: string, hideNumber = true): RequestHandler {
     return async (req, res, next) => {

--- a/express/src/middleware/validators/notOnCommonPasswordListValidator.ts
+++ b/express/src/middleware/validators/notOnCommonPasswordListValidator.ts
@@ -1,30 +1,21 @@
 import {RequestHandler} from "express";
-import CommonPasswords from "../../lib/commonPasswords/commonPasswordsSingleton";
+import isCommonPassword from "../../lib/commonPasswords/CommonPasswords";
 
-const ERROR_MESSAGE = "Enter a stronger password. Do not use very common passwords like ‘password’ or a sequence of numbers.";
+const errorMessage = "Enter a stronger password. Do not use very common passwords like ‘password’ or a sequence of numbers.";
 
-export default function notOnCommonPasswordListValidator(
-    template: string,
-    passwordField: string,
-    valuesToRender?: string[]
-): RequestHandler {
+export default function checkPasswordAllowed(template: string, passwordField = "password", valuesToRender = ["password"]): RequestHandler {
     return async (req, res, next) => {
-        if ((await CommonPasswords).notOnList(req.body[passwordField])) {
-            next();
-        } else {
-            const values: {[fieldName: string]: string} = {};
-            if (valuesToRender) {
-                valuesToRender.forEach(v => {
-                    values[v] = req.body[v];
-                });
-            }
+        const isCommon = await isCommonPassword(req.body[passwordField]);
 
-            res.render(template, {
-                values: values,
-                errorMessages: {
-                    [passwordField]: ERROR_MESSAGE
-                }
-            });
+        if (!isCommon) {
+            return next();
         }
+
+        res.render(template, {
+            values: Object.fromEntries(valuesToRender?.map(field => [field, req.body[field]])),
+            errorMessages: {
+                [passwordField]: errorMessage
+            }
+        });
     };
 }

--- a/express/src/middleware/validators/passwordValidator.ts
+++ b/express/src/middleware/validators/passwordValidator.ts
@@ -1,5 +1,5 @@
 import {RequestHandler} from "express";
-import {validatePassword} from "../../lib/validators/passwordValidator";
+import validatePassword from "../../lib/validators/password-validator";
 import {validationResult} from "../../lib/validators/validationResult";
 
 export function passwordValidator(render: string): RequestHandler {

--- a/express/src/middleware/validators/urisValidator.ts
+++ b/express/src/middleware/validators/urisValidator.ts
@@ -1,5 +1,5 @@
 import {RequestHandler} from "express";
-import {validateUris} from "../../lib/validators/urisValidator";
+import validateUris from "../../lib/validators/uris-validator";
 
 export function urisValidator(template: string): RequestHandler {
     return (req, res, next) => {

--- a/express/tests/lib/allowed-email-domains.test.ts
+++ b/express/tests/lib/allowed-email-domains.test.ts
@@ -1,4 +1,4 @@
-import {validateEmail} from "../../src/lib/validators/emailValidator";
+import hasAllowedDomain from "lib/validators/allowed-email-domains";
 
 jest.mock("fs/promises", () => {
     return {
@@ -12,29 +12,29 @@ const allowedSubDomain = ".partial.subdomain";
 describe("Verify email domains", () => {
     describe("Accept valid domains", () => {
         it("Allows an email address with a domain on the allowed list", async () => {
-            expect((await validateEmail(`email@${allowedDomain}`)).isValid).toBe(true);
+            expect(await hasAllowedDomain(`email@${allowedDomain}`)).toBe(true);
         });
 
         it("Allows an email address ending with a domain on the allowed list", async () => {
-            expect((await validateEmail(`email@top.level.${allowedDomain}`)).isValid).toBe(true);
+            expect(await hasAllowedDomain(`email@top.level.${allowedDomain}`)).toBe(true);
         });
 
         it("Allows an email address ending with a subdomain on the allowed list", async () => {
-            expect((await validateEmail(`email@top.level${allowedSubDomain}`)).isValid).toBe(true);
+            expect(await hasAllowedDomain(`email@top.level${allowedSubDomain}`)).toBe(true);
         });
     });
 
     describe("Reject invalid domains", () => {
         it("Rejects an email address with a domain not on the allowed list", async () => {
-            expect((await validateEmail("email@bad.domain")).isValid).toBe(false);
+            expect(await hasAllowedDomain("email@bad.domain")).toBe(false);
         });
 
         it("Rejects an email address not ending with a domain on the allowed list", async () => {
-            expect((await validateEmail(`email@${allowedDomain}.subdomain`)).isValid).toBe(false);
+            expect(await hasAllowedDomain(`email@${allowedDomain}.subdomain`)).toBe(false);
         });
 
         it("Rejects an email address not ending with a subdomain on the allowed list", async () => {
-            expect((await validateEmail(`email@top.level.${allowedSubDomain}.subdomain`)).isValid).toBe(false);
+            expect(await hasAllowedDomain(`email@top.level.${allowedSubDomain}.subdomain`)).toBe(false);
         });
     });
 });

--- a/express/tests/lib/commonPasswords.test.ts
+++ b/express/tests/lib/commonPasswords.test.ts
@@ -1,14 +1,17 @@
-import commonPasswordsSingleton from "lib/commonPasswords/commonPasswordsSingleton";
+import isCommonPassword from "lib/commonPasswords/CommonPasswords";
 
-const COMMON_PASSWORD = "Password123";
-const UNCOMMON_PASSWORD = "this-is-not-a-common-password";
+jest.mock("fs/promises", () => {
+    return {
+        readFile: jest.fn(() => "common-password")
+    };
+});
 
-describe("Only common passwords are excluded", () => {
-    it(`Does not allow ${COMMON_PASSWORD}`, async () => {
-        expect((await commonPasswordsSingleton).notOnList(COMMON_PASSWORD)).toBe(false);
+describe("Check if a password is allowed", () => {
+    it("Reject a commonly used password", async () => {
+        expect(await isCommonPassword("common-password")).toBe(true);
     });
 
-    it(`Does allow ${UNCOMMON_PASSWORD}`, async () => {
-        expect((await commonPasswordsSingleton).notOnList(UNCOMMON_PASSWORD)).toBe(true);
+    it("Accept a password not on the common passwords list", async () => {
+        expect(await isCommonPassword("unique-password")).toBe(false);
     });
 });

--- a/express/tests/lib/validators/checkOtp.test.ts
+++ b/express/tests/lib/validators/checkOtp.test.ts
@@ -1,4 +1,4 @@
-import {validateSecurityCode} from "../../../src/lib/validators/checkOtp";
+import validateSecurityCode from "lib/validators/checkOtp";
 
 describe("Validate security codes", () => {
     it("Accept valid 6 digit codes", () => {

--- a/express/tests/lib/validators/emailValidator.test.ts
+++ b/express/tests/lib/validators/emailValidator.test.ts
@@ -1,4 +1,4 @@
-import {validateEmail} from "lib/validators/emailValidator";
+import validateEmail from "lib/validators/emailValidator";
 
 const EMAIL_WITH_ALLOWED_DOMAIN = "allowed@email.gov.uk";
 const EMAIL_WITH_DISALLOWED_DOMAIN = "allowed@hackers.co.uk";

--- a/express/tests/lib/validators/passwordValidator.test.ts
+++ b/express/tests/lib/validators/passwordValidator.test.ts
@@ -1,4 +1,4 @@
-import {validatePassword} from "lib/validators/passwordValidator";
+import validatePassword from "lib/validators/password-validator";
 
 const PASSWORD_WITH_EMPTY_VALUE = "";
 const PASSWORD_LESS_THAN_8_CHAR = "123";

--- a/express/tests/lib/validators/urisValidator.test.ts
+++ b/express/tests/lib/validators/urisValidator.test.ts
@@ -1,4 +1,4 @@
-import {validateUris} from "lib/validators/urisValidator";
+import validateUris from "lib/validators/uris-validator";
 
 describe("URIs are correctly validated", () => {
     it("rejects an empty array", () => {


### PR DESCRIPTION
- Add a validator for allowed domains to encapsulate the logic for verifying emails
- Use default exports in validators
- Streamline the logic and trim down the code
---
- Common passwords validator - export a function instead of a class
- Public key utils - extract the key content and wrap it in headers to ensure whitespace and newlines inside the key are removed