### PR TITLE
BAU: Update Cognito and Lambda clients

### DIFF
--- a/express/.env.example
+++ b/express/.env.example
@@ -4,4 +4,5 @@ API_BASE_URL= # API ID can be found at https://eu-west-2.console.aws.amazon.com/
 SESSION_STORAGE= # DynamoDB any other value will use in memory session storage.
 SESSIONS_TABLE= # Sessions table name can be found at https://eu-west-2.console.aws.amazon.com/dynamodbv2/home?region=eu-west-2#tables. It is one of the the table in the list with this pattern <DeployedStackName>-Sessions-XXXXXXX
 DYNAMO_DB_ENDPOINT= # http://localhost:8000, if you need to overwrite to local or any other dynamoDB endpoint.
+AWS_REGION=eu-west-2
 PORT=3000

--- a/express/package.json
+++ b/express/package.json
@@ -3,7 +3,7 @@
   "description": "DI self-service frontend",
   "scripts": {
     "start": "node dist/app.js",
-    "local": "npm run build && node --inspect -r 'dotenv/config' dist/app.js",
+    "local": "npm run buildts && node --inspect -r 'dotenv/config' dist/app.js",
     "dev": "COGNITO_CLIENT=${COGNITO_CLIENT:-StubCognitoClient} LAMBDA_FACADE=${LAMBDA_FACADE:-StubLambdaFacade} nodemon --config nodemon.json --inspect -r 'dotenv/config' src/app.ts",
     "docker": "docker run --rm --publish 3000:3000 self-service-frontend",
     "minifyjs": "for script in dist/assets/javascripts/*.js; do uglifyjs $script -cmo $script $(${CI:-false} || echo --source-map includeSources,url=${script##*/}.map); done",

--- a/express/src/config/environment.ts
+++ b/express/src/config/environment.ts
@@ -1,0 +1,20 @@
+export const port = process.env.PORT ?? 3000;
+export const awsRegion = process.env.AWS_REGION;
+export const googleTagId = process.env.GOOGLE_TAG_ID;
+
+export const cognito = {
+    client: process.env.COGNITO_CLIENT ?? "CognitoClient",
+    userPoolId: process.env.USERPOOL_ID,
+    clientId: process.env.CLIENT_ID
+};
+
+export const lambda = {
+    facade: process.env.LAMBDA_FACADE ?? "LambdaFacade",
+    apiBaseUrl: process.env.API_BASE_URL
+};
+
+export const sessionStorage = {
+    store: process.env.SESSION_STORAGE,
+    tableName: process.env.SESSIONS_TABLE,
+    dynamoDbEndpoint: process.env.DYNAMO_DB_ENDPOINT
+};

--- a/express/src/config/express.ts
+++ b/express/src/config/express.ts
@@ -1,4 +1,5 @@
 import express, {Express} from "express";
+import "express-async-errors";
 import "../lib/utils/optional";
 import RequestContext from "../types/request-context";
 import "./session-data";

--- a/express/src/config/session-storage.ts
+++ b/express/src/config/session-storage.ts
@@ -2,21 +2,21 @@ import {DynamoDB} from "@aws-sdk/client-dynamodb";
 import connect_dynamodb from "connect-dynamodb";
 import {RequestHandler} from "express";
 import session from "express-session";
+import {awsRegion, sessionStorage} from "./environment";
 
 export default getSessionStorage();
 
 function getSessionStorage(): RequestHandler {
-    if (process.env.SESSION_STORAGE === "DynamoDB") {
-        const table = process.env.SESSIONS_TABLE;
-        const endpoint = process.env.DYNAMO_DB_ENDPOINT;
-        const region = process.env.AWS_REGION ?? "eu-west-2";
-        const client = new DynamoDB({region: region, endpoint: endpoint});
+    if (sessionStorage.store === "DynamoDB") {
+        const table = sessionStorage.tableName;
+        const endpoint = sessionStorage.dynamoDbEndpoint;
+        const client = new DynamoDB({region: awsRegion, endpoint: endpoint});
         console.log(`Using dynamoDB session storage | Table: ${table} | Endpoint: ${endpoint ?? "AWS"}`);
 
         const options = {
             table: table,
             client: client,
-            AWSRegion: region
+            AWSRegion: awsRegion
         };
 
         const DynamoDBStore = connect_dynamodb({session: session});

--- a/express/src/controllers/clients.ts
+++ b/express/src/controllers/clients.ts
@@ -9,7 +9,7 @@ export const showClient: RequestHandler = async (req, res) => {
     // TODO make S4 instances static in all controllers
     const serviceId = req.context.serviceId;
     const s4: SelfServiceServicesService = req.app.get("backing-service");
-    const client = (await s4.listClients(nonNull(serviceId), nonNull(req.session.authenticationResult?.AccessToken)))[0];
+    const client = (await s4.listClients(nonNull(serviceId)))[0];
     const selfServiceClientId = client.dynamoServiceId;
     const authClientId = client.authClientId;
     const serviceName = client.serviceName;
@@ -97,13 +97,7 @@ export const processPrivateBetaForm: RequestHandler = async (req, res) => {
     }
 
     const s4: SelfServiceServicesService = req.app.get("backing-service");
-    await s4.privateBetaRequest(
-        userName,
-        department,
-        serviceName,
-        emailAddress as string,
-        nonNull(req.session.authenticationResult?.AccessToken)
-    );
+    await s4.privateBetaRequest(userName, department, serviceName, nonNull(emailAddress));
 
     res.redirect(`/services/${serviceId}/clients/${clientId}/${selfServiceClientId}/private-beta/submitted`);
 };

--- a/express/src/controllers/services.ts
+++ b/express/src/controllers/services.ts
@@ -1,11 +1,10 @@
-import {AuthenticationResultType} from "@aws-sdk/client-cognito-identity-provider";
 import {Request, Response} from "express";
 import AuthenticationResultParser from "../lib/authentication-result-parser";
 import SelfServiceServicesService from "../services/self-service-services-service";
 
 export const listServices = async function (req: Request, res: Response) {
     const s4: SelfServiceServicesService = req.app.get("backing-service");
-    const userId = AuthenticationResultParser.getCognitoId(req.session.authenticationResult as AuthenticationResultType);
+    const userId = AuthenticationResultParser.getCognitoId(nonNull(req.session.authenticationResult));
 
     if (userId == undefined) {
         console.log(req.query);
@@ -14,7 +13,8 @@ export const listServices = async function (req: Request, res: Response) {
         return;
     }
 
-    const services = await s4.listServices(userId as string, req.session.authenticationResult?.AccessToken as string);
+    const services = await s4.listServices(userId);
+
     if (services.length === 0) {
         res.redirect(`/register/create-service`);
         return;

--- a/express/src/controllers/sign-in.ts
+++ b/express/src/controllers/sign-in.ts
@@ -1,6 +1,5 @@
 import {AuthenticationResultType, LimitExceededException, UserNotFoundException} from "@aws-sdk/client-cognito-identity-provider";
 import {NextFunction, Request, Response} from "express";
-import "express-async-errors";
 import AuthenticationResultParser from "../lib/authentication-result-parser";
 import {obscureNumber} from "../lib/mobile-number";
 import SelfServiceServicesService from "../services/self-service-services-service";

--- a/express/src/routes/register.ts
+++ b/express/src/routes/register.ts
@@ -1,5 +1,4 @@
 import {Router} from "express";
-import "express-async-errors";
 import path from "path";
 import {
     accountExists,

--- a/express/src/services/cognito/CognitoInterface.ts
+++ b/express/src/services/cognito/CognitoInterface.ts
@@ -1,43 +1,35 @@
 import {
-    AdminCreateUserCommandOutput,
     AdminInitiateAuthCommandOutput,
     AdminRespondToAuthChallengeCommandOutput,
-    AdminSetUserMFAPreferenceCommandOutput,
-    AdminUpdateUserAttributesCommandOutput,
-    ChangePasswordCommandOutput,
-    ConfirmForgotPasswordCommandOutput,
-    ForgotPasswordCommandOutput,
-    GetUserAttributeVerificationCodeCommandOutput,
-    RespondToAuthChallengeCommandOutput,
-    VerifyUserAttributeCommandOutput
+    RespondToAuthChallengeCommandOutput
 } from "@aws-sdk/client-cognito-identity-provider";
 
 export default interface CognitoInterface {
-    createUser(email: string): Promise<AdminCreateUserCommandOutput>;
+    createUser(email: string): Promise<void>;
 
-    resendEmailAuthCode(email: string): Promise<AdminCreateUserCommandOutput>;
+    resendEmailAuthCode(email: string): Promise<void>;
 
     login(email: string, password: string): Promise<AdminInitiateAuthCommandOutput>;
 
     setNewPassword(email: string, password: string, session: string): Promise<RespondToAuthChallengeCommandOutput>;
 
-    changePassword(accessToken: string, previousPassword: string, proposedPassword: string): Promise<ChangePasswordCommandOutput>;
+    changePassword(accessToken: string, previousPassword: string, proposedPassword: string): Promise<void>;
 
-    forgotPassword(email: string, uri: string): Promise<ForgotPasswordCommandOutput>;
+    forgotPassword(email: string, uri: string): Promise<void>;
 
-    confirmForgotPassword(username: string, password: string, confirmationCode: string): Promise<ConfirmForgotPasswordCommandOutput>;
+    confirmForgotPassword(username: string, password: string, confirmationCode: string): Promise<void>;
 
-    setEmailAsVerified(username: string): Promise<AdminUpdateUserAttributesCommandOutput>;
+    setEmailAsVerified(username: string): Promise<void>;
 
-    setMobilePhoneAsVerified(username: string): Promise<AdminUpdateUserAttributesCommandOutput>;
+    setMobilePhoneAsVerified(username: string): Promise<void>;
 
-    setPhoneNumber(username: string, phoneNumber: string): Promise<AdminUpdateUserAttributesCommandOutput>;
+    setPhoneNumber(username: string, phoneNumber: string): Promise<void>;
 
-    sendMobileNumberVerificationCode(accessToken: string): Promise<GetUserAttributeVerificationCodeCommandOutput>;
+    sendMobileNumberVerificationCode(accessToken: string): Promise<void>;
 
-    verifyMobileUsingSmsCode(accessToken: string, code: string): Promise<VerifyUserAttributeCommandOutput>;
+    verifyMobileUsingSmsCode(accessToken: string, code: string): Promise<void>;
 
-    setMfaPreference(cognitoUsername: string): Promise<AdminSetUserMFAPreferenceCommandOutput>;
+    setMfaPreference(cognitoUsername: string): Promise<void>;
 
     respondToMfaChallenge(username: string, mfaCode: string, session: string): Promise<AdminRespondToAuthChallengeCommandOutput>;
 

--- a/express/src/services/cognito/StubCognitoClient.ts
+++ b/express/src/services/cognito/StubCognitoClient.ts
@@ -1,19 +1,12 @@
 import {
-    AdminCreateUserCommandOutput,
     AdminInitiateAuthCommandOutput,
     AdminRespondToAuthChallengeCommandOutput,
-    AdminSetUserMFAPreferenceCommandOutput,
-    AdminUpdateUserAttributesCommandOutput,
-    ChangePasswordCommandOutput,
     CodeMismatchException,
     CognitoIdentityProviderServiceException,
-    ForgotPasswordCommandOutput,
-    GetUserAttributeVerificationCodeCommandOutput,
     NotAuthorizedException,
     RespondToAuthChallengeCommandOutput,
     UsernameExistsException,
-    UserNotFoundException,
-    VerifyUserAttributeCommandOutput
+    UserNotFoundException
 } from "@aws-sdk/client-cognito-identity-provider";
 import {MetadataBearer} from "@aws-sdk/types";
 import * as crypto from "crypto";
@@ -21,6 +14,70 @@ import {promises as fs} from "fs";
 import path from "path";
 import {convertToCountryPrefixFormat} from "../../lib/mobile-number";
 import CognitoInterface from "./CognitoInterface";
+
+const kid = {kid: "bIXchwnF2Iyc/lFMKTHBvG+R6x1ea9ZN3sEegxjnL/k=", alg: "RS256"};
+
+const accessTokenPayload = {
+    sub: "11abcd56-a1e6-11f3-918c-40a8d79e9480",
+    device_key: "eu-west-2_2f622f4f-a3d7-4a7f-bee9-558fc2ce34c1",
+    iss: "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_QdCNCN9jn",
+    client_id: "447m7e0o3bomrnskmi5sp95v6g",
+    origin_jti: "745d4ab4-11b5-4910-ab2d-03fac9fe22fd",
+    event_id: "e612d1de-840f-4bca-af32-5a49d0d2f2e8",
+    token_use: "access",
+    scope: "aws.cognito.signin.user.admin",
+    auth_time: 1663256712,
+    exp: 1663260312,
+    iat: 1663256712,
+    jti: "bb59c20c-d73e-4f04-bdd5-5d852f163e3a",
+    username: "11abcd56-a1e6-11f3-918c-40a8d79e9480"
+};
+
+const idTokenPayload = {
+    sub: "11abcd56-a1e6-11f3-918c-40a8d79e9480",
+    iss: "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_QdCNCN9jn",
+    "cognito:username": "11abcd56-a1e6-11f3-918c-40a8d79e9480",
+    origin_jti: "745d4ab4-11b5-4910-ab2d-03fac9fe22fd",
+    aud: "447m7e0o3bomrnskmi5sp95v6g",
+    event_id: "e612d1de-840f-4bca-af32-5a49d0d2f2e8",
+    token_use: "id",
+    auth_time: 1663256712,
+    exp: 1663260312,
+    iat: 1663256712,
+    jti: "4eacc4a3-ca35-42b0-9d11-71730e38ea40",
+    email: "testing@gds.gov.uk"
+};
+
+const loggedInIdTokenPayload = {
+    sub: "11abcd56-a1e6-11f3-918c-40a8d79e9480",
+    email_verified: true,
+    iss: "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_QdCNCN9jn",
+    phone_number_verified: true,
+    "cognito:username": "11abcd56-a1e6-11f3-918c-40a8d79e9480",
+    origin_jti: "9f1f1c2f-3461-4208-92e4-ec23cf3b4ac0",
+    aud: "447m7e0o3bomrnskmi5sp95v6g",
+    event_id: "33a92542-10b1-488f-aaf9-aa2de7fbc63e",
+    token_use: "id",
+    auth_time: 1663314206,
+    phone_number: "+447958170405",
+    exp: 1663317806,
+    iat: 1663314206,
+    jti: "ebc1a631-daac-4005-8bff-acf736b1e309",
+    email: "testing@gds.gov.uk"
+};
+
+const authenticationResult = {
+    AccessToken: getAccessToken(),
+    ExpiresIn: 3600,
+    IdToken: getIdToken(),
+    NewDeviceMetadata: {
+        DeviceGroupKey: "-M2nI29X6",
+        DeviceKey: "eu-west-2_bb745d49-5a3a-46d4-b71e-af50d89d4108"
+    },
+    RefreshToken:
+        "eyJjdHkiOiJKV1QiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiUlNBLU9BRVAifQ.kVb6S9vSwaYEU7QHrN1mkCDCMOWCep_NRy9M6P40DRr5RHVqb7493CyMLNS1-pd1zLErT5rSrSG7_pbao-jxQwRrs8oWut1Jm1tRH3gfGbQ6zHrFQLwKTdK9baQCa2R-KZ7MD_1AIKN_OASNv9nyLF1zbUY6qBzXWcucXAfvOr73NGVVhuSKk8C0jaOTANDA0xk755pSzTeQ571UFfpvHaHeH0DWjSKxbXYm3EjfBbb4xWMb2w_ZvGoyO41SnCV15z-Wd_c-kAWXGFi7AekVqPQ2vdY8LpdgZCTfBe9sVXZB8Q4SiOhaFQU6DUx6HEn8Q5z3QcdO3PtrkOxJ6qfG2A.UWgNu3fNWWd1_uxg.s1XwWW4FFcuAZ7ek__bqoEUWNcA9YalSg0cVzW537kNr7-1gtVocVLIAXV80-R7uGmG4T0yM3YBmOkH_D1ctaONsVUNkgXawSZNf3KXoAsOlEBPQPkjuV8cZ9BQo6RkpNjt7GZQ2BGc9nTSOmPuSOBJMEA8MiDieo-c1fFbTGMnMy7vB3mt1QNGEzOvvwfRJEhcPAaxhu4akOpcf-x8Z8Gl7nCiJl8uunRhMCzmEwKUuNLhszlQJ7wYMvnzz3IjaharZKR9TAJ7kyn32nKkUj8RokRVsJ3rRG6LjIUSrWmafNP8VpQIshShV6n-Id9ItTp9F68aX4zv1xP_tbNekLJ9Oj4ZwB2LXMxHuA_enyq43ylKohGj7vp01OuExI3hAxg0cG45GHNb4_sTZXzMfOXQ5ycsXqsMrotw25r7Qlax8Ap0S1kZ44wqVzkHqSHbO6h72BFY4sycYDd4Q_SXDB_i8r4Oo_eOXEPdS2X1tMElsoGT4fvdenIxc-YG0jB7KEGvnUWOj7V2RNZVl5fVYtEoR19kPOwlkH5fJsqIb_5d6uL7-6AWZl8cF9jDDm_CwYv5-BMxpjnlTkNwB5uUcowDu8x1eBstEWyjn2pbdQQu_DD_uXvHDZBjm8ky74g24bGMB_YgAoaADDjCal317Tu2TCQGoloY2qGZjX6xydiJT13LlX97VDEw0lKqWvHAVZjjIwCT04kvT9uu5nvFGcBYA3y-Wzgs8h8Zc4mQXBiitAC2Vec3k2tI5rmNiuSUDTheC31T_KIjMBudEbEN0m7TBcrLvUFF7VP3ToenCuw72wRbeW7Ypulf-b30GOg9ODbQicqny7NCjgpw3cZtQyQKeRVxhQbto6XML2enfUGvFOVkYTddQLR6MfHftki5T9DyiL4Z2nM_7_dhWRYj2vOWXRYpXyVcm2foatZmlEOEWvggvdYfXXY3jmPElyAERcrqw0tUIwqjtGUuPrjP3uZQ7wzCpYyYTeluysQZEoG1pSQhrEATpEVUyep8G0Dgfuf-H8qdR9viVZx3V0kfZrEcJvZJoy3F6b40Jr_njRBekyXyB8GsZvYdWgdxdFP5fm8T_xS2bSXpiGMml6QFdx7POzXdxvTetbC6blAf1wmwPeb-YeVqcX4-XsBQ0EmNMPt9ip2oNfMZ9UpoT0H2ILXBVKE_IHNGJ5iGEnjjLxVD7NpuoavZsRd_Kpjmz5jXUJQzAOL1E1FPkQcjKQY8bm1YeZNUWgeNxW8x9H4p9zH0w0kWEDl2KubSYXeGhN2JjGxx3ZFtJbL3S7JJQviSKYIawTfxKFDrHE5Bs85N3grwmRzuGd6yUfA9NsH2CmU_gj0uTnJ22WvVQ5tyVDWBRkAmW1R6Ts498MeHUojxmaRBA7Hlh4J2SKM6p1vrH-gWk6UhbI6Gc8dxolAW0mMLvyGRch_AP9fwXekjxOOxb.1vTUzN815BSOGPdA9hsQCw",
+    TokenType: "Bearer"
+};
 
 type CognitoResponse = MetadataBearer;
 
@@ -31,155 +88,63 @@ type Override = {
     throw?: string;
 };
 
-/* eslint-disable @typescript-eslint/no-unused-vars --
- * Ignore unused vars in stubs
- */
-export class CognitoClient implements CognitoInterface {
-    kid = {kid: "bIXchwnF2Iyc/lFMKTHBvG+R6x1ea9ZN3sEegxjnL/k=", alg: "RS256"};
-
-    accessTokenPayload = {
-        sub: "11abcd56-a1e6-11f3-918c-40a8d79e9480",
-        device_key: "eu-west-2_2f622f4f-a3d7-4a7f-bee9-558fc2ce34c1",
-        iss: "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_QdCNCN9jn",
-        client_id: "447m7e0o3bomrnskmi5sp95v6g",
-        origin_jti: "745d4ab4-11b5-4910-ab2d-03fac9fe22fd",
-        event_id: "e612d1de-840f-4bca-af32-5a49d0d2f2e8",
-        token_use: "access",
-        scope: "aws.cognito.signin.user.admin",
-        auth_time: 1663256712,
-        exp: 1663260312,
-        iat: 1663256712,
-        jti: "bb59c20c-d73e-4f04-bdd5-5d852f163e3a",
-        username: "11abcd56-a1e6-11f3-918c-40a8d79e9480"
-    };
-
-    idTokenPayload = {
-        sub: "11abcd56-a1e6-11f3-918c-40a8d79e9480",
-        iss: "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_QdCNCN9jn",
-        "cognito:username": "11abcd56-a1e6-11f3-918c-40a8d79e9480",
-        origin_jti: "745d4ab4-11b5-4910-ab2d-03fac9fe22fd",
-        aud: "447m7e0o3bomrnskmi5sp95v6g",
-        event_id: "e612d1de-840f-4bca-af32-5a49d0d2f2e8",
-        token_use: "id",
-        auth_time: 1663256712,
-        exp: 1663260312,
-        iat: 1663256712,
-        jti: "4eacc4a3-ca35-42b0-9d11-71730e38ea40",
-        email: "testing@gds.gov.uk"
-    };
-
-    loggedInIdTokenPayload = {
-        sub: "11abcd56-a1e6-11f3-918c-40a8d79e9480",
-        email_verified: true,
-        iss: "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_QdCNCN9jn",
-        phone_number_verified: true,
-        "cognito:username": "11abcd56-a1e6-11f3-918c-40a8d79e9480",
-        origin_jti: "9f1f1c2f-3461-4208-92e4-ec23cf3b4ac0",
-        aud: "447m7e0o3bomrnskmi5sp95v6g",
-        event_id: "33a92542-10b1-488f-aaf9-aa2de7fbc63e",
-        token_use: "id",
-        auth_time: 1663314206,
-        phone_number: "+447958170405",
-        exp: 1663317806,
-        iat: 1663314206,
-        jti: "ebc1a631-daac-4005-8bff-acf736b1e309",
-        email: "testing@gds.gov.uk"
-    };
-
-    authenticationResult = {
-        AccessToken: "replace using getIdToken()",
-        ExpiresIn: 3600,
-        IdToken: "replace using getAccessToken()",
-        NewDeviceMetadata: {
-            DeviceGroupKey: "-M2nI29X6",
-            DeviceKey: "eu-west-2_bb745d49-5a3a-46d4-b71e-af50d89d4108"
-        },
-        RefreshToken:
-            "eyJjdHkiOiJKV1QiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiUlNBLU9BRVAifQ.kVb6S9vSwaYEU7QHrN1mkCDCMOWCep_NRy9M6P40DRr5RHVqb7493CyMLNS1-pd1zLErT5rSrSG7_pbao-jxQwRrs8oWut1Jm1tRH3gfGbQ6zHrFQLwKTdK9baQCa2R-KZ7MD_1AIKN_OASNv9nyLF1zbUY6qBzXWcucXAfvOr73NGVVhuSKk8C0jaOTANDA0xk755pSzTeQ571UFfpvHaHeH0DWjSKxbXYm3EjfBbb4xWMb2w_ZvGoyO41SnCV15z-Wd_c-kAWXGFi7AekVqPQ2vdY8LpdgZCTfBe9sVXZB8Q4SiOhaFQU6DUx6HEn8Q5z3QcdO3PtrkOxJ6qfG2A.UWgNu3fNWWd1_uxg.s1XwWW4FFcuAZ7ek__bqoEUWNcA9YalSg0cVzW537kNr7-1gtVocVLIAXV80-R7uGmG4T0yM3YBmOkH_D1ctaONsVUNkgXawSZNf3KXoAsOlEBPQPkjuV8cZ9BQo6RkpNjt7GZQ2BGc9nTSOmPuSOBJMEA8MiDieo-c1fFbTGMnMy7vB3mt1QNGEzOvvwfRJEhcPAaxhu4akOpcf-x8Z8Gl7nCiJl8uunRhMCzmEwKUuNLhszlQJ7wYMvnzz3IjaharZKR9TAJ7kyn32nKkUj8RokRVsJ3rRG6LjIUSrWmafNP8VpQIshShV6n-Id9ItTp9F68aX4zv1xP_tbNekLJ9Oj4ZwB2LXMxHuA_enyq43ylKohGj7vp01OuExI3hAxg0cG45GHNb4_sTZXzMfOXQ5ycsXqsMrotw25r7Qlax8Ap0S1kZ44wqVzkHqSHbO6h72BFY4sycYDd4Q_SXDB_i8r4Oo_eOXEPdS2X1tMElsoGT4fvdenIxc-YG0jB7KEGvnUWOj7V2RNZVl5fVYtEoR19kPOwlkH5fJsqIb_5d6uL7-6AWZl8cF9jDDm_CwYv5-BMxpjnlTkNwB5uUcowDu8x1eBstEWyjn2pbdQQu_DD_uXvHDZBjm8ky74g24bGMB_YgAoaADDjCal317Tu2TCQGoloY2qGZjX6xydiJT13LlX97VDEw0lKqWvHAVZjjIwCT04kvT9uu5nvFGcBYA3y-Wzgs8h8Zc4mQXBiitAC2Vec3k2tI5rmNiuSUDTheC31T_KIjMBudEbEN0m7TBcrLvUFF7VP3ToenCuw72wRbeW7Ypulf-b30GOg9ODbQicqny7NCjgpw3cZtQyQKeRVxhQbto6XML2enfUGvFOVkYTddQLR6MfHftki5T9DyiL4Z2nM_7_dhWRYj2vOWXRYpXyVcm2foatZmlEOEWvggvdYfXXY3jmPElyAERcrqw0tUIwqjtGUuPrjP3uZQ7wzCpYyYTeluysQZEoG1pSQhrEATpEVUyep8G0Dgfuf-H8qdR9viVZx3V0kfZrEcJvZJoy3F6b40Jr_njRBekyXyB8GsZvYdWgdxdFP5fm8T_xS2bSXpiGMml6QFdx7POzXdxvTetbC6blAf1wmwPeb-YeVqcX4-XsBQ0EmNMPt9ip2oNfMZ9UpoT0H2ILXBVKE_IHNGJ5iGEnjjLxVD7NpuoavZsRd_Kpjmz5jXUJQzAOL1E1FPkQcjKQY8bm1YeZNUWgeNxW8x9H4p9zH0w0kWEDl2KubSYXeGhN2JjGxx3ZFtJbL3S7JJQviSKYIawTfxKFDrHE5Bs85N3grwmRzuGd6yUfA9NsH2CmU_gj0uTnJ22WvVQ5tyVDWBRkAmW1R6Ts498MeHUojxmaRBA7Hlh4J2SKM6p1vrH-gWk6UhbI6Gc8dxolAW0mMLvyGRch_AP9fwXekjxOOxb.1vTUzN815BSOGPdA9hsQCw",
-        TokenType: "Bearer"
-    };
-
-    overrides: Promise<string>;
+class StubCognitoClient implements CognitoInterface {
+    private readonly overrides: Promise<Record<string, Override[]>> = fs
+        .readFile(path.join(__dirname, "../../../stubs/stubs-config.json"))
+        .then(buffer => JSON.parse(buffer.toString()));
 
     constructor() {
         console.log("Creating stub Cognito client...");
-        this.overrides = fs.readFile(path.join(__dirname, "../../../stubs/stubs-config.json")).then(buffer => buffer.toString());
-        this.authenticationResult.IdToken = this.getIdToken();
-        this.authenticationResult.AccessToken = this.getAccessToken();
     }
 
-    base64EncodeToken(token: object): string {
-        return Buffer.from(JSON.stringify(token), "utf-8").toString("base64");
+    async createUser(email: string): Promise<void> {
+        await this.getOverriddenReturnValue("createUser", "email", email);
     }
 
-    fakeSignature(): string {
-        return Buffer.from(crypto.randomBytes(32)).toString("base64");
+    async resendEmailAuthCode(email: string): Promise<void> {
+        await this.getOverriddenReturnValue("login", "email", email);
     }
 
-    getIdToken(): string {
-        return `${this.base64EncodeToken(this.kid)}.${this.base64EncodeToken(this.idTokenPayload)}.${this.fakeSignature()}`;
-    }
-
-    getLoggedInIdToken(): string {
-        return `${this.base64EncodeToken(this.kid)}.${this.base64EncodeToken(this.loggedInIdTokenPayload)}.${this.fakeSignature()}`;
-    }
-
-    getAccessToken(): string {
-        return `${this.base64EncodeToken(this.kid)}.${this.base64EncodeToken(this.accessTokenPayload)}.${this.fakeSignature()}`;
-    }
-
-    async createUser(email: string): Promise<AdminCreateUserCommandOutput> {
-        const returnValue = await this.getOverriddenReturnValue("createUser", "email", email);
-        return Promise.resolve(returnValue ?? {$metadata: {}});
-    }
-
-    async resendEmailAuthCode(email: string): Promise<AdminCreateUserCommandOutput> {
+    async login(email: string): Promise<AdminInitiateAuthCommandOutput> {
         const returnValue = await this.getOverriddenReturnValue("login", "email", email);
         return Promise.resolve(returnValue ?? {$metadata: {}});
     }
 
-    async login(email: string, password: string): Promise<AdminInitiateAuthCommandOutput> {
-        const returnValue = await this.getOverriddenReturnValue("login", "email", email);
-        return Promise.resolve(returnValue ?? {$metadata: {}});
+    async sendMobileNumberVerificationCode(): Promise<void> {
+        return;
     }
 
-    sendMobileNumberVerificationCode(accessToken: string): Promise<GetUserAttributeVerificationCodeCommandOutput> {
-        return Promise.resolve({$metadata: {}});
+    async forgotPassword(): Promise<void> {
+        return;
     }
 
-    forgotPassword(email: string, uri: string): Promise<ForgotPasswordCommandOutput> {
-        return Promise.resolve({$metadata: {}});
+    async confirmForgotPassword(): Promise<void> {
+        return;
     }
 
-    confirmForgotPassword(username: string, password: string, confirmationCode: string): Promise<ForgotPasswordCommandOutput> {
-        return Promise.resolve({$metadata: {}});
+    async setEmailAsVerified(): Promise<void> {
+        return;
     }
 
-    setEmailAsVerified(username: string): Promise<AdminUpdateUserAttributesCommandOutput> {
-        return Promise.resolve({UserAttributes: [{Name: "email", Value: username}], $metadata: {}});
-    }
-
-    async setNewPassword(email: string, password: string, session: string): Promise<RespondToAuthChallengeCommandOutput> {
+    async setNewPassword(email: string, password: string): Promise<RespondToAuthChallengeCommandOutput> {
         const returnValue = await this.getOverriddenReturnValue("setNewPassword", "password", password);
         return Promise.resolve(returnValue ?? {$metadata: {}});
     }
 
-    changePassword(accessToken: string, previousPassword: string, proposedPassword: string): Promise<ChangePasswordCommandOutput> {
-        return Promise.resolve({$metadata: {}});
+    async changePassword(): Promise<void> {
+        return;
     }
 
-    setPhoneNumber(username: string, phoneNumber: string): Promise<AdminUpdateUserAttributesCommandOutput> {
-        this.loggedInIdTokenPayload.phone_number = convertToCountryPrefixFormat(phoneNumber);
-        return Promise.resolve({$metadata: {}});
+    async setPhoneNumber(username: string, phoneNumber: string): Promise<void> {
+        loggedInIdTokenPayload.phone_number = convertToCountryPrefixFormat(phoneNumber);
     }
 
-    async verifyMobileUsingSmsCode(accessToken: string, code: string): Promise<VerifyUserAttributeCommandOutput> {
-        const returnValue = await this.getOverriddenReturnValue("verifySmsCode", "code", code);
-        return Promise.resolve(returnValue ?? {$metadata: {}});
+    async verifyMobileUsingSmsCode(accessToken: string, code: string): Promise<void> {
+        await this.getOverriddenReturnValue("verifySmsCode", "code", code);
     }
 
-    setMfaPreference(cognitoUsername: string): Promise<AdminSetUserMFAPreferenceCommandOutput> {
-        return Promise.resolve({$metadata: {}});
+    async setMfaPreference(): Promise<void> {
+        return;
     }
 
     private async getOverriddenReturnValue(method: string, parameter: string, value: string): Promise<CognitoResponse | undefined> {
@@ -197,13 +162,7 @@ export class CognitoClient implements CognitoInterface {
     }
 
     private async getOverrideFor(method: string, parameter: string, value: string): Promise<Override | undefined> {
-        const overrides = await this.overrides;
-        if (overrides === undefined) {
-            return undefined;
-        }
-
-        const parsedOverrides: Record<string, Override[]> = JSON.parse(overrides);
-        const methodOverrides = parsedOverrides[method];
+        const methodOverrides = (await this.overrides)[method];
 
         if (methodOverrides === undefined) {
             return undefined;
@@ -227,18 +186,34 @@ export class CognitoClient implements CognitoInterface {
         throw new Error("Unknown exception");
     }
 
-    async respondToMfaChallenge(username: string, mfaCode: string, session: string): Promise<AdminRespondToAuthChallengeCommandOutput> {
+    async respondToMfaChallenge(username: string): Promise<AdminRespondToAuthChallengeCommandOutput> {
         const returnValue = await this.getOverriddenReturnValue("respondToMfaChallenge", "username", username);
         return Promise.resolve(returnValue ?? {$metadata: {}});
     }
 
-    setMobilePhoneAsVerified(username: string): Promise<AdminUpdateUserAttributesCommandOutput> {
-        return Promise.resolve({$metadata: {}});
+    async setMobilePhoneAsVerified(): Promise<void> {
+        return;
     }
 
-    useRefreshToken(refreshToken: string): Promise<AdminInitiateAuthCommandOutput> {
-        return Promise.resolve({AuthenticationResult: this.authenticationResult, $metadata: {}});
+    useRefreshToken(): Promise<AdminInitiateAuthCommandOutput> {
+        return Promise.resolve({AuthenticationResult: authenticationResult, $metadata: {}});
     }
 }
 
-module.exports = {CognitoClient};
+function getIdToken(): string {
+    return `${base64EncodeToken(kid)}.${base64EncodeToken(idTokenPayload)}.${fakeSignature()}`;
+}
+
+function getAccessToken(): string {
+    return `${base64EncodeToken(kid)}.${base64EncodeToken(accessTokenPayload)}.${fakeSignature()}`;
+}
+
+function base64EncodeToken(token: object): string {
+    return Buffer.from(JSON.stringify(token), "utf-8").toString("base64");
+}
+
+function fakeSignature(): string {
+    return Buffer.from(crypto.randomBytes(32)).toString("base64");
+}
+
+export default new StubCognitoClient();

--- a/express/src/services/lambda-facade/LambdaFacadeInterface.ts
+++ b/express/src/services/lambda-facade/LambdaFacadeInterface.ts
@@ -3,37 +3,33 @@ import {QueryCommandOutput} from "@aws-sdk/client-dynamodb";
 import {AxiosResponse} from "axios";
 import {OnboardingTableItem} from "../../../@types/OnboardingTableItem";
 import {Service} from "../../../@types/Service";
-import {Updates} from "../self-service-services-service";
+
+export type UserUpdates = Record<string, string | Date>;
+export type ClientUpdates = Record<string, string | string[]>;
 
 export default interface LambdaFacadeInterface {
-    putUser(user: OnboardingTableItem, accessToken: string): Promise<AxiosResponse>;
+    putUser(user: OnboardingTableItem, accessToken: string): Promise<void>;
 
-    updateUser(selfServiceUserId: string, updates: Updates, accessToken: string): Promise<AxiosResponse>;
+    updateUser(selfServiceUserId: string, updates: UserUpdates, accessToken: string): Promise<void>;
 
     getUserByCognitoId(cognitoId: string, accessToken: string): Promise<AxiosResponse>;
 
-    newService(service: Service, userId: string, email: string, accessToken: string): Promise<AxiosResponse>;
+    newService(service: Service, userId: string, email: string, accessToken: string): Promise<void>;
 
     generateClient(service: Service, authenticationResult: AuthenticationResultType): Promise<AxiosResponse>;
 
-    listServices(userId: string, accessToken: string): Promise<AxiosResponse>;
+    listServices(userId: string): Promise<AxiosResponse>;
 
     // TODO The QueryCommandOutput type should be replaced by a class shared between the frontend and the API (contract)
-    listClients(serviceId: string, accessToken: string): Promise<AxiosResponse<QueryCommandOutput>>;
+    listClients(serviceId: string): Promise<AxiosResponse<QueryCommandOutput>>;
+
+    privateBetaRequest(name: string, department: string, serviceName: string, emailAddress: string): Promise<void>;
 
     updateClient(
         serviceId: string,
         selfServiceClientId: string,
         clientId: string,
-        updates: object,
+        updates: ClientUpdates,
         accessToken: string
-    ): Promise<AxiosResponse<QueryCommandOutput>>;
-
-    privateBetaRequest(
-        name: string,
-        department: string,
-        serviceName: string,
-        emailAddress: string,
-        accessToken: string
-    ): Promise<AxiosResponse>;
+    ): Promise<void>;
 }

--- a/express/src/services/lambda-facade/StubLambdaFacade.ts
+++ b/express/src/services/lambda-facade/StubLambdaFacade.ts
@@ -1,19 +1,13 @@
-import {AuthenticationResultType} from "@aws-sdk/client-cognito-identity-provider";
 import {QueryCommandOutput} from "@aws-sdk/client-dynamodb";
 import {convertToAttr} from "@aws-sdk/util-dynamodb";
 import {AxiosResponse} from "axios";
-import {OnboardingTableItem} from "../../../@types/OnboardingTableItem";
 import {Service} from "../../../@types/Service";
 import {DynamoUser} from "../../../@types/user";
-import {Updates} from "../self-service-services-service";
-import LambdaFacadeInterface from "./LambdaFacadeInterface";
+import LambdaFacadeInterface, {ClientUpdates, UserUpdates} from "./LambdaFacadeInterface";
 
 const defaultPublicKey =
     "MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAp2mLkQGo24Kz1rut0oZlviMkGomlQCH+iT1pFvegZFXq39NPjRWyatmXp/XIUPqCq9Kk8/+tq4Sgjw+EM5tATJ06j5r+35of58ATGVPniW//IhGizrv6/ebGcGEUJ0Y/ZmlCHYPV+lbewpttQ/IYKM1nr3k/Rl6qepbVYe+MpGubluQvdhgUYel9OzxiOvUk7XI0axPquiXzoEgmNNOai8+WhYTkBqE3/OucAv+XwXdnx4XHmKzMwTv93dYMpUmvTxWcSeEJ/4/SrbiK4PyHWVKU2BozfSUejVNhahAzZeyyDwhYJmhBaZi/3eOOlqGXj9UdkOXbl3vcwBH8wD30O9/4F5ERLKxzOaMnKZ+RpnygWF0qFhf+UeFMy+O06sdgiaFnXaSCsIy/SohspkKiLjNnhvrDNmPLMQbQKQlJdcp6zUzI7Gzys7luEmOxyMpA32lDBQcjL7KNwM15s4ytfrJ46XEPZUXESce2gj6NazcPPsrTa/Q2+oLS9GWupGh7AgMBAAE=";
 
-/* eslint-disable @typescript-eslint/no-unused-vars --
- * Ignore unused vars in stubs
- */
 class StubLambdaFacade implements LambdaFacadeInterface {
     private publicKey = defaultPublicKey;
     private serviceName = "Test Service";
@@ -36,7 +30,7 @@ class StubLambdaFacade implements LambdaFacadeInterface {
         console.log("Creating stub Lambda facade...");
     }
 
-    getUserByCognitoId(cognitoId: string, accessToken: string): Promise<AxiosResponse> {
+    getUserByCognitoId(): Promise<AxiosResponse> {
         return Promise.resolve({
             data: {
                 Item: this.user
@@ -44,16 +38,15 @@ class StubLambdaFacade implements LambdaFacadeInterface {
         } as AxiosResponse);
     }
 
-    newService(service: Service, userId: string, email: string, accessToken: string): Promise<AxiosResponse> {
+    async newService(service: Service): Promise<void> {
         this.serviceName = service.serviceName;
-        return Promise.resolve({data: {output: JSON.stringify({serviceId: "stub-service-id"})}} as AxiosResponse);
     }
 
-    putUser(user: OnboardingTableItem, accessToken: string): Promise<AxiosResponse> {
-        return Promise.resolve({} as AxiosResponse);
+    async putUser(): Promise<void> {
+        return;
     }
 
-    generateClient(service: Service, authenticationResult: AuthenticationResultType): Promise<AxiosResponse> {
+    generateClient(): Promise<AxiosResponse> {
         return Promise.resolve({
             data: {
                 output: JSON.stringify({body: JSON.stringify({pk: "stub-service-id"})})
@@ -61,13 +54,7 @@ class StubLambdaFacade implements LambdaFacadeInterface {
         } as AxiosResponse);
     }
 
-    updateClient(
-        serviceId: string,
-        selfServiceClientId: string,
-        clientId: string,
-        updates: Record<string, string | string[]>,
-        accessToken: string
-    ): Promise<AxiosResponse> {
+    async updateClient(serviceId: string, selfServiceClientId: string, clientId: string, updates: ClientUpdates): Promise<void> {
         if (updates.public_key) {
             this.publicKey = updates.public_key as string;
         }
@@ -87,11 +74,9 @@ class StubLambdaFacade implements LambdaFacadeInterface {
         if (updates.scopes) {
             this.scopes = updates.scopes as string[];
         }
-
-        return Promise.resolve({} as AxiosResponse);
     }
 
-    listServices(userId: string, accessToken: string): Promise<AxiosResponse> {
+    listServices(): Promise<AxiosResponse> {
         return Promise.resolve({
             data: {
                 Items: [
@@ -107,7 +92,7 @@ class StubLambdaFacade implements LambdaFacadeInterface {
         } as AxiosResponse);
     }
 
-    listClients(serviceId: string, accessToken: string): Promise<AxiosResponse<QueryCommandOutput>> {
+    listClients(): Promise<AxiosResponse<QueryCommandOutput>> {
         return Promise.resolve({
             data: {
                 Items: [
@@ -144,20 +129,13 @@ class StubLambdaFacade implements LambdaFacadeInterface {
         } as AxiosResponse);
     }
 
-    updateUser(selfServiceUserId: string, updates: Updates, accessToken: string): Promise<AxiosResponse> {
+    async updateUser(selfServiceUserId: string, updates: UserUpdates): Promise<void> {
         Object.keys(updates).forEach(key => (this.user[key as keyof DynamoUser] = {S: updates[key] as string}));
-        return Promise.resolve({} as AxiosResponse);
     }
 
-    privateBetaRequest(
-        name: string,
-        department: string,
-        serviceName: string,
-        emailAddress: string,
-        accessToken: string
-    ): Promise<AxiosResponse> {
-        return Promise.resolve({} as AxiosResponse);
+    async privateBetaRequest(): Promise<void> {
+        return;
     }
 }
 
-export const lambdaFacadeInstance = new StubLambdaFacade();
+export default new StubLambdaFacade();


### PR DESCRIPTION
Tidy up clients for Cognito and Lambda
Add methods to send requests and use them in all functions for consistent usage
Remove unnecessary return types and async, or return void if the output is not used

Add config for env vars to manage them all in one place and set defaults as needed