### PR TITLE
SSE-2623 Fix broken link for password reset

### DIFF
--- a/backend/cognito/src/handlers/password-reset-custom-message.ts
+++ b/backend/cognito/src/handlers/password-reset-custom-message.ts
@@ -13,7 +13,7 @@ async function forgotPassword(event: CustomMessageForgotPasswordTriggerEvent): P
 
     const code = event.request.codeParameter;
     const username = encodeURIComponent(clientMetadata.username);
-    const link = `${clientMetadata.uri}/create-new-password?userName=${username}&confirmationCode=${code}`;
+    const link = `${clientMetadata.uri}/sign-in/forgot-password/create-new-password?loginName=${username}&confirmationCode=${code}`;
 
     event.response = {
         smsMessage: "",


### PR DESCRIPTION
Amend path in reset password email that wasn't updated when the routes were rearranged.