### PR TITLE
BAU add missing permissions to StepFunctionExecutionPolicy

### DIFF
--- a/infrastructure/api/sse-api.yml
+++ b/infrastructure/api/sse-api.yml
@@ -445,11 +445,15 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogDelivery
+                  - logs:CreateLogStream
                   - logs:GetLogDelivery
                   - logs:UpdateLogDelivery
                   - logs:DeleteLogDelivery
                   - logs:ListLogDeliveries
+                  - logs:PutLogEvents
+                  - logs:PutResourcePolicy
                   - logs:DescribeResourcePolicies
+                  - logs:DescribeLogGroups
                 Resource: "*"
               - Effect: Allow
                 Action: logs:DescribeLogGroups


### PR DESCRIPTION
More permission are needed for the step function to be able to log to a specific log group.