### PR TITLE
SSE-2622 Export the actual domain

### DIFF
--- a/backend/cognito/email-identity-template.yml
+++ b/backend/cognito/email-identity-template.yml
@@ -44,6 +44,11 @@ Resources:
 Outputs:
   EmailIdentityArn:
     Description: ARN of the created email identity
-    Value: !Ref DomainIdentityForSES
+    Value: !Sub arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:identity/${DomainToVerify}
     Export:
       Name: EmailIdentityArn
+  EmailDomain:
+    Description: The domain that will be used for the email identity
+    Value: !Ref DomainToVerify
+    Export:
+      Name: EmailDomain

--- a/backend/cognito/template.yml
+++ b/backend/cognito/template.yml
@@ -3,9 +3,6 @@ Description: Cognito UserPool and Client
 Transform: AWS::Serverless-2016-10-31
 
 Parameters:
-  EmailDomain:
-    Type: String
-    Description: Domain or email that will be created as verified identity.
   ExternalId:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /self-service/config/cognito/external-id
@@ -49,10 +46,10 @@ Resources:
             Resource: !ImportValue EmailIdentityArn
             Condition:
               StringEquals:
-                "ses:FromAddress": !Sub 'admin-tool@${EmailDomain}'
+                "ses:FromAddress": !Sub ['admin-tool@${emailDomain}', {emailDomain: !ImportValue EmailDomain}]
       Environment:
         Variables:
-          FROM_EMAIL_ADDRESS: !Sub 'admin-tool@${EmailDomain}'
+          FROM_EMAIL_ADDRESS: !Sub ['admin-tool@${emailDomain}', {emailDomain: !ImportValue EmailDomain}]
 
       Handler: src/handlers/confirm-forgot-password-message.handler
       Runtime: nodejs14.x
@@ -426,7 +423,7 @@ Resources:
       EmailConfiguration:
         EmailSendingAccount: DEVELOPER
         SourceArn: !ImportValue EmailIdentityArn
-        From: !Sub 'admin-tool@${EmailDomain}'
+        From: !Sub ['admin-tool@${emailDomain}', {emailDomain: !ImportValue EmailDomain}]
       SmsConfiguration:
         SnsCallerArn: !GetAtt SmsRole.Arn
         ExternalId: !Ref ExternalId


### PR DESCRIPTION
We need to export the domain too - it's coupled with the identity created so it makes sense; it then reduces the required parameters for the actual cognito template.