### PR TITLE
SSE-2549: Add Auth API key config for lambdas using the Auth API

### DIFF
--- a/backend/api/src/handlers/auth/register-client.ts
+++ b/backend/api/src/handlers/auth/register-client.ts
@@ -4,14 +4,15 @@ import axios, {Axios} from "axios"; // TODO: Until Onboarding takes over client 
 const instance: Axios = axios.create({
     baseURL: process.env.AUTH_REGISTRATION_BASE_URL,
     headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        "X-API-Key": process.env.AUTH_API_KEY as string
     }
 });
 
 export const registerClientHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
     // TODO remove explicit any
+    // eslint-disable-next-line
     const payload: any = event;
-
     const public_key =
         "MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAp2mLkQGo24Kz1rut0oZlviMkGomlQCH+iT1pFvegZFXq39NPjRWyatmXp/XIUPqCq9Kk8/+tq4Sgjw+EM5tATJ06j5r+35of58ATGVPniW//IhGizrv6/ebGcGEUJ0Y/ZmlCHYPV+lbewpttQ/IYKM1nr3k/Rl6qepbVYe+MpGubluQvdhgUYel9OzxiOvUk7XI0axPquiXzoEgmNNOai8+WhYTkBqE3/OucAv+XwXdnx4XHmKzMwTv93dYMpUmvTxWcSeEJ/4/SrbiK4PyHWVKU2BozfSUejVNhahAzZeyyDwhYJmhBaZi/3eOOlqGXj9UdkOXbl3vcwBH8wD30O9/4F5ERLKxzOaMnKZ+RpnygWF0qFhf+UeFMy+O06sdgiaFnXaSCsIy/SohspkKiLjNnhvrDNmPLMQbQKQlJdcp6zUzI7Gzys7luEmOxyMpA32lDBQcjL7KNwM15s4ytfrJ46XEPZUXESce2gj6NazcPPsrTa/Q2+oLS9GWupGh7AgMBAAE=";
 

--- a/backend/api/src/handlers/auth/update-client.ts
+++ b/backend/api/src/handlers/auth/update-client.ts
@@ -5,11 +5,14 @@ import axios, {Axios} from "axios";
 const instance: Axios = axios.create({
     baseURL: process.env.AUTH_REGISTRATION_BASE_URL,
     headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        "X-API-Key": process.env.AUTH_API_KEY as string
     }
 });
+
 export const updateClientInRegistryHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
     // TODO remove explicit any
+    // eslint-disable-next-line
     const payload: any = event;
     const result = await (await instance).put(`/connect/register/${payload.clientId}`, payload.updates);
 

--- a/infrastructure/api/sse-api.yml
+++ b/infrastructure/api/sse-api.yml
@@ -319,6 +319,7 @@ Resources:
       Environment:
         Variables:
           AUTH_REGISTRATION_BASE_URL: !Ref AuthRegistrationBaseUrl
+          AUTH_API_KEY: "{{resolve:ssm:/self-service/api/auth-api-key}}"
 
   UpdateAuthClientFunction:
     # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
@@ -336,6 +337,7 @@ Resources:
       Environment:
         Variables:
           AUTH_REGISTRATION_BASE_URL: !Ref AuthRegistrationBaseUrl
+          AUTH_API_KEY: "{{resolve:ssm:/self-service/api/auth-api-key}}"
 
   #--- Step Functions ---#
 


### PR DESCRIPTION
- Add header for Auth API key
- Add env var for the key

The lambdas should really be using the SSM SDK to access the secret directly rather than store it in the env and expose it. Raising this for now so we can complete testing.