### PR TITLE
BAU Fix broken script

### DIFF
--- a/infrastructure/ci/development-stacks/deploy-development-stack.sh
+++ b/infrastructure/ci/development-stacks/deploy-development-stack.sh
@@ -19,7 +19,7 @@ STACK_PREFIX="$1"
 BASE_DIR="$(dirname "${BASH_SOURCE[0]}")"
 pushd "$BASE_DIR" > /dev/null
 
-../../check-aws-account.sh development
+../../aws.sh check-current-account development
 
 cat ./unnecessary-ddb-banner.txt
 


### PR DESCRIPTION
The script which sets a new developer up with a set of working stacks broke because the `check-aws-account.sh` got replaced with something else.

Fix that.