### PR TITLE
SSE-2679 - Update the dashboard to indicate that OpenID is always a required attribute

### DIFF
--- a/express/src/views/clients/change-user-attributes.njk
+++ b/express/src/views/clients/change-user-attributes.njk
@@ -10,6 +10,7 @@
        class="govuk-link" target="_blank">user attributes (opens in new tab)</a> you would like your service to receive.
     These are also known as ‘scopes’ in the OpenID Connect (OIDC) specification.
   </p>
+  <p class="govuk-body">By default, the OpenID scope is always enabled for your service.</p>
 {% endblock %}
 
 {% block formInputs %}

--- a/express/src/views/clients/client-details.njk
+++ b/express/src/views/clients/client-details.njk
@@ -6,6 +6,7 @@
 
 {% set userAttributes %}
   {% for item in userAttributesRequired %}
+    {% if item == "openid" %}OpenID<br>{% endif %}
     {% if item == "email" %}Email address<br>{% endif %}
     {% if item == "phone" %}Phone number<br>{% endif %}
     {% if item == "offline_access" %}Offline access{% endif %}


### PR DESCRIPTION
Update the dashboard to indicate that OpenID is always a required attribute