### PR TITLE
SSE-2685: Update development deployment scripts

### DIFF
--- a/backend/api/api.template.yml
+++ b/backend/api/api.template.yml
@@ -9,7 +9,7 @@ Parameters:
     Description: API Gateway endpoint for client registration
   NotificationEmail:
     Type: AWS::SSM::Parameter::Value<String>
-    Default: /self-service/api/notification-email
+    Default: /self-service/api/notifications-email
     Description: Email address to send internal notifications
   LogGroupNamePrefix:
     Type: String

--- a/backend/cognito/cognito.template.yml
+++ b/backend/cognito/cognito.template.yml
@@ -32,6 +32,9 @@ Globals:
     Timeout: 10
     Runtime: nodejs18.x
     PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
+    Environment:
+      Variables:
+        NODE_OPTIONS: --enable-source-maps
 
 Resources:
   SendPasswordChangedEmailFunction:

--- a/backend/dynamodb/dynamodb.template.yml
+++ b/backend/dynamodb/dynamodb.template.yml
@@ -45,6 +45,7 @@ Resources:
             ProjectionType: ALL
 
   SessionsTable:
+    # https://github.com/ca98am79/connect-dynamodb#options
     # checkov:skip=CKV_AWS_28: "Ensure Dynamodb point in time recovery (backup) is enabled"
     # checkov:skip=CKV_AWS_119: "Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK"
     Type: AWS::DynamoDB::Table

--- a/express/.env.example
+++ b/express/.env.example
@@ -2,6 +2,5 @@ COGNITO_USER_POOL_ID= # Can be found at https://eu-west-2.console.aws.amazon.com
 COGNITO_CLIENT_ID= # Can be found at https://eu-west-2.console.aws.amazon.com/cognito/v2/idp/user-pools/<above user pool ID>/app-integration?region=eu-west-2 at the bottom of the page in the second column
 API_BASE_URL= # API ID can be found at https://eu-west-2.console.aws.amazon.com/apigateway/main/apis?region=eu-west-2 in the third column.  Substitute the value into this: https://<API ID goes here>.execute-api.eu-west-2.amazonaws.com
 SESSIONS_TABLE= # Sessions table name can be found at https://eu-west-2.console.aws.amazon.com/dynamodbv2/home?region=eu-west-2#tables. It is one of the the table in the list with this pattern <DeployedStackName>-Sessions-XXXXXXX
-DYNAMO_DB_ENDPOINT= # http://localhost:8000, if you need to overwrite to local or any other dynamoDB endpoint.
 AWS_REGION=eu-west-2
 PORT=3000

--- a/express/src/config/environment.ts
+++ b/express/src/config/environment.ts
@@ -1,7 +1,7 @@
 export const port = process.env.PORT ?? 3000;
-export const awsRegion = process.env.AWS_REGION;
 export const googleTagId = process.env.GOOGLE_TAG_ID;
 export const showTestBanner = process.env.SHOW_TEST_BANNER === "true";
+export const region = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION;
 
 export const cognito = {
     client: process.env.COGNITO_CLIENT ?? "CognitoClient",
@@ -15,6 +15,5 @@ export const api = {
 };
 
 export const sessionStorage = {
-    tableName: process.env.SESSIONS_TABLE,
-    dynamoDbEndpoint: process.env.DYNAMO_DB_ENDPOINT
+    tableName: process.env.SESSIONS_TABLE
 };

--- a/express/src/config/session-storage.ts
+++ b/express/src/config/session-storage.ts
@@ -1,37 +1,30 @@
-import {DynamoDB} from "@aws-sdk/client-dynamodb";
-import connect_dynamodb from "connect-dynamodb";
+import connect from "connect-dynamodb";
 import {RequestHandler} from "express";
 import session from "express-session";
-import {awsRegion, sessionStorage} from "./environment";
+import {region, sessionStorage} from "./environment";
+import {DynamoDB} from "@aws-sdk/client-dynamodb";
 
 export default getSessionStorage();
 
 function getSessionStorage(): RequestHandler {
     if (sessionStorage.tableName) {
-        const table = sessionStorage.tableName;
-        const endpoint = sessionStorage.dynamoDbEndpoint;
-        const client = new DynamoDB({region: awsRegion, endpoint: endpoint});
-        console.log(`Using DynamoDB session storage | Table: ${table} | Endpoint: ${endpoint ?? "AWS"}`);
-
-        const options = {
-            table: table,
-            client: client,
-            AWSRegion: awsRegion
-        };
-
-        const DynamoDBStore = connect_dynamodb({session: session});
+        console.log("Using DynamoDB session storage");
+        const DynamoDBStore = connect({session: session});
         return session({
-            store: new DynamoDBStore(options),
             secret: "keyboard cat",
-            cookie: {maxAge: 1000 * 60 * 60}
+            cookie: {maxAge: 1000 * 60 * 60},
+            store: new DynamoDBStore({
+                table: sessionStorage.tableName,
+                client: new DynamoDB({region: region})
+            })
         });
     }
 
     console.log("Using in-memory session storage");
     return session({
         secret: "setting_this_will_never_cause_problems_in_future",
-        saveUninitialized: true,
         cookie: {maxAge: 1_000 * 60 * 60 * 24},
+        saveUninitialized: true,
         resave: false
     });
 }

--- a/express/src/services/cognito/CognitoClient.ts
+++ b/express/src/services/cognito/CognitoClient.ts
@@ -19,7 +19,7 @@ import {
     VerifyUserAttributeCommand
 } from "@aws-sdk/client-cognito-identity-provider";
 import {Command} from "@aws-sdk/types";
-import {awsRegion, cognito} from "../../config/environment";
+import {cognito, region} from "../../config/environment";
 import CognitoInterface from "./CognitoInterface";
 
 type CognitoCommand<Input extends ServiceInputTypes, Output extends ServiceOutputTypes> = Command<
@@ -43,7 +43,7 @@ class CognitoClient implements CognitoInterface {
         console.log("Creating Cognito client...");
         this.clientId = nonNull(cognito.clientId);
         this.userPoolId = nonNull(cognito.userPoolId);
-        this.client = new CognitoIdentityProviderClient({region: awsRegion});
+        this.client = new CognitoIdentityProviderClient({region: region});
     }
 
     async createUser(email: string): Promise<void> {

--- a/infrastructure/aws.sh
+++ b/infrastructure/aws.sh
@@ -11,6 +11,10 @@ function get-account-group {
   jq --arg name "$1" 'with_entries(select(.value | contains([{name: $name}]))) | flatten' aws-accounts.json
 }
 
+function get-account-group-name {
+  jq --raw-output --arg name "$1" 'to_entries | .[] | select(.value | contains([{name: $name}])) | .key' aws-accounts.json
+}
+
 function get-account-number {
   jq --exit-status --arg name "$1" 'select(.name == $name) | .number' < <(get-all-accounts)
 }
@@ -37,10 +41,8 @@ function get-previous-account-name {
 }
 
 function get-downstream-accounts {
-  local name=$1 accounts
-  [[ $name == $(get-initial-account "$name") ]] || return 0
-  accounts=$(get-higher-accounts-in-group "$name")
-  echo "${accounts:=$(get-account-number "$name")}"
+  local name=$1
+  [[ $name == $(get-initial-account "$name") ]] && get-higher-accounts-in-group "$name"
 }
 
 function get-account-index-in-group {

--- a/infrastructure/ci/configure-deployment-parameters.sh
+++ b/infrastructure/ci/configure-deployment-parameters.sh
@@ -27,12 +27,12 @@ function check-secret-set {
 }
 
 function get-parameter-value {
-  aws ssm get-parameter --name "${PARAMETERS[$1]}" --query "Parameter.Value" --output text 2> /dev/null
+  aws ssm get-parameter --name "$1" --query "Parameter.Value" --output text 2> /dev/null
 }
 
 function write-parameter-value {
   echo "Setting '$1' to '$2'"
-  aws ssm put-parameter --name "${PARAMETERS[$1]}" --value "$(xargs <<< "$2")" --type String --overwrite > /dev/null
+  aws ssm put-parameter --name "$1" --value "$(xargs <<< "$2")" --type String --overwrite > /dev/null
 }
 
 function write-secret-value {
@@ -48,9 +48,12 @@ function get-value-from-user {
 
 function check-manual-parameters {
   local parameter
-  for parameter in "${MANUAL_PARAMETERS[@]}"; do
-    check-parameter-set "$parameter" || write-parameter-value "$parameter" "$(get-value-from-user "$parameter")"
-  done
+  for parameter in "${MANUAL_PARAMETERS[@]}"; do check-parameter "${PARAMETERS[$parameter]}"; done
+}
+
+function check-parameter {
+  local parameter=$1
+  check-parameter-set "$parameter" || write-parameter-value "$parameter" "$(get-value-from-user "$parameter")"
 }
 
 function check-secret {
@@ -64,19 +67,21 @@ function check-secrets {
 }
 
 function check-cognito-external-id {
-  check-parameter-set cognito_external_id || write-parameter-value cognito_external_id "$(uuidgen)"
+  local parameter=${PARAMETERS[cognito_external_id]}
+  check-parameter-set "$parameter" || write-parameter-value "$parameter" "$(uuidgen)"
 }
 
 function check-deletion-protection {
-  check-parameter-set deletion_protection ||
-    write-parameter-value deletion_protection "$([[ $ACCOUNT == production ]] && echo ACTIVE || echo INACTIVE)"
+  local parameter=${PARAMETERS[deletion_protection]}
+  check-parameter-set "$parameter" ||
+    write-parameter-value "$parameter" "$([[ $ACCOUNT == production ]] && echo ACTIVE || echo INACTIVE)"
 }
 
 function print-parameters {
   local parameter
   echo "--- Deployment parameters ---"
-  for parameter in "${!PARAMETERS[@]}"; do
-    echo "${PARAMETERS[$parameter]}: $(get-parameter-value "$parameter")"
+  for parameter in "${PARAMETERS[@]}"; do
+    echo "$parameter: $(get-parameter-value "$parameter")"
   done
 }
 

--- a/infrastructure/ci/configure-deployment-parameters.sh
+++ b/infrastructure/ci/configure-deployment-parameters.sh
@@ -10,7 +10,7 @@ MANUAL_PARAMETERS=(api_notification_email)
 declare -A PARAMETERS=(
   [cognito_external_id]=$PARAMETER_NAME_PREFIX/cognito/external-id
   [deletion_protection]=$PARAMETER_NAME_PREFIX/config/deletion-protection-enabled
-  [api_notification_email]=$PARAMETER_NAME_PREFIX/api/notification-email
+  [api_notification_email]=$PARAMETER_NAME_PREFIX/api/notifications-email
 )
 
 declare -A SECRETS=(

--- a/infrastructure/ci/secure-pipelines/deploy-support-stacks.sh
+++ b/infrastructure/ci/secure-pipelines/deploy-support-stacks.sh
@@ -3,8 +3,9 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 set -eu
 
 ACCOUNT=$(../../aws.sh get-current-account-name)
-DOWNSTREAM_ACCOUNTS=$(../../aws.sh get-downstream-accounts "$ACCOUNT")
 [[ $ACCOUNT =~ ^development|production$ ]] && ENV_TYPE=$ACCOUNT
+../../aws.sh is-initial-account "$ACCOUNT" && INITIAL_ACCOUNT=true &&
+  DOWNSTREAM_ACCOUNTS=$(../../aws.sh get-downstream-accounts "$ACCOUNT")
 
 GRAFANA_SECRET_NAME=/self-service/secure-pipelines/grafana-api-key
 ../configure-deployment-parameters.sh check-secret $GRAFANA_SECRET_NAME
@@ -15,7 +16,7 @@ GRAFANA_SECRET_NAME=/self-service/secure-pipelines/grafana-api-key
   --stack-name secure-pipelines-support \
   --template deployment-support.template.yml \
   --tags Product="GOV.UK One Login" System="Dev Platform" Service="ci/cd" Owner="Self-Service Team" Environment="$ACCOUNT" \
-  --parameters EnvironmentType="${ENV_TYPE:-test}" DownstreamAccounts="${DOWNSTREAM_ACCOUNTS:-''}" \
-  GrafanaKeySecretName="$GRAFANA_SECRET_NAME"
+  --parameters InitialAccount=${INITIAL_ACCOUNT:-false} EnvironmentType="${ENV_TYPE:-test}" \
+  DownstreamAccounts="${DOWNSTREAM_ACCOUNTS:-''}" GrafanaKeySecretName="$GRAFANA_SECRET_NAME"
 
 ./configure-github-repo.sh update-deployment-environment

--- a/infrastructure/ci/secure-pipelines/deploy-support-stacks.sh
+++ b/infrastructure/ci/secure-pipelines/deploy-support-stacks.sh
@@ -8,6 +8,7 @@ DOWNSTREAM_ACCOUNTS=$(../../aws.sh get-downstream-accounts "$ACCOUNT")
 
 GRAFANA_SECRET_NAME=/self-service/secure-pipelines/grafana-api-key
 ../configure-deployment-parameters.sh check-secret $GRAFANA_SECRET_NAME
+../configure-deployment-parameters.sh check-parameter /self-service/secure-pipelines/developer-notification-email
 
 ../../deploy-sam-stack.sh "$@" \
   --validate \

--- a/infrastructure/ci/secure-pipelines/deployment-pipelines.template.yml
+++ b/infrastructure/ci/secure-pipelines/deployment-pipelines.template.yml
@@ -84,6 +84,7 @@ Resources:
         IncludePromotion: !If [ PromotionEnabled, "Yes", "No" ]
         AccessLogsCustomBucketNameEnabled: "No"
         ProgrammaticPermissionsBoundary: "True"
+        PipelineEnvironentNameEnabled: "Yes"
         AllowedServiceOne: Lambda
         AllowedServiceTwo: DynamoDB
         AllowedServiceThree: SNS
@@ -115,6 +116,7 @@ Resources:
         IncludePromotion: !If [ PromotionEnabled, "Yes", "No" ]
         AccessLogsCustomBucketNameEnabled: "No"
         ProgrammaticPermissionsBoundary: "True"
+        PipelineEnvironentNameEnabled: "Yes"
         AllowedServiceOne: Cognito
         AllowedServiceTwo: Lambda
         AllowedServiceThree: SNS
@@ -145,6 +147,7 @@ Resources:
         IncludePromotion: !If [ PromotionEnabled, "Yes", "No" ]
         AccessLogsCustomBucketNameEnabled: "No"
         ProgrammaticPermissionsBoundary: "True"
+        PipelineEnvironentNameEnabled: "Yes"
         AllowedServiceOne: DynamoDB
 
   FrontendDeployer:
@@ -177,6 +180,7 @@ Resources:
         IncludePromotion: !If [ PromotionEnabled, "Yes", "No" ]
         AccessLogsCustomBucketNameEnabled: "No"
         ProgrammaticPermissionsBoundary: "True"
+        PipelineEnvironentNameEnabled: "Yes"
         AllowedServiceOne: ECR & ECS
 
   FrontendECRRepository:

--- a/infrastructure/ci/secure-pipelines/deployment-support.template.yml
+++ b/infrastructure/ci/secure-pipelines/deployment-support.template.yml
@@ -22,6 +22,9 @@ Parameters:
   GrafanaKeySecretName:
     Type: String
     Default: /self-service/secure-pipelines/grafana-api-key
+  DeveloperNotificationsEmail:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /self-service/secure-pipelines/developer-notification-email
 
 Mappings:
   Grafana:
@@ -90,7 +93,14 @@ Resources:
       TemplateURL: !Sub ${TemplateStorageBucket}/build-notifications/template.yaml
       Parameters:
         SlackWorkspaceId: T8GT9416G
-        SlackChannelId: !FindInMap [ Slack, channel, !Ref EnvironmentType, { DefaultValue: !FindInMap [ Slack, channel, default ] } ]
+        SlackChannelId: !FindInMap [ Slack, Channel, !Ref EnvironmentType, { DefaultValue: !FindInMap [ Slack, Channel, default ] } ]
+
+  ECRScanningNotifications:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub ${TemplateStorageBucket}/ecr-image-scan-findings-logger/template.yaml
+      Parameters:
+        NotificationEmail: !Ref DeveloperNotificationsEmail
 
   LambdaAuditHook:
     Type: AWS::CloudFormation::Stack

--- a/infrastructure/ci/secure-pipelines/deployment-support.template.yml
+++ b/infrastructure/ci/secure-pipelines/deployment-support.template.yml
@@ -12,6 +12,10 @@ Parameters:
     Default: secure-pipelines
     AllowedPattern: ^.*[^-]$
     Description: Prefix to use when importing or exporting values
+  InitialAccount:
+    Type: String
+    Default: No
+    AllowedValues: [ Yes, No ]
   EnvironmentType:
     Type: String
     Default: test
@@ -28,23 +32,24 @@ Parameters:
 
 Mappings:
   Grafana:
-    env:
+    Env:
       production: prod
       default: non-prod
   Slack:
-    channel:
+    Channel:
       development: C04QFSGKCGG    # di-sse-dev-notifications
       default: C02T6P3NVDX        # di-sse-tech-notifications
 
 Conditions:
-  IsInitialAccount: !Not [ !Equals [ !Ref DownstreamAccounts, "" ] ]
-  IsDevelopmentAccount: !Equals [ !Ref EnvironmentType, development ]
-  IsInitialProductionAccount: !And [ !Condition IsInitialAccount, !Not [ !Condition IsDevelopmentAccount ] ]
+  InitialAccount: !Equals [ !Ref InitialAccount, Yes ]
+  DevelopmentAccount: !Equals [ !Ref EnvironmentType, development ]
+  InitialDevelopmentAccount: !And [ !Condition InitialAccount, !Condition DevelopmentAccount ]
+  InitialProductionAccount: !And [ !Condition InitialAccount, !Not [ !Condition DevelopmentAccount ] ]
 
 Resources:
   GitHubIdentityProvider:
     Type: AWS::CloudFormation::Stack
-    Condition: IsInitialProductionAccount
+    Condition: InitialProductionAccount
     Properties:
       TemplateURL: !Sub ${TemplateStorageBucket}/github-identity/template.yaml
       Parameters:
@@ -52,8 +57,16 @@ Resources:
 
   ContainerSigner:
     Type: AWS::CloudFormation::Stack
-    Condition: IsInitialProductionAccount
+    Condition: InitialProductionAccount
     DependsOn: GitHubIdentityProvider
+    Properties:
+      TemplateURL: !Sub ${TemplateStorageBucket}/container-signer/template.yaml
+      Parameters:
+        AllowedAccounts: !Ref DownstreamAccounts
+
+  DevelopmentContainerSigner:
+    Type: AWS::CloudFormation::Stack
+    Condition: InitialDevelopmentAccount
     Properties:
       TemplateURL: !Sub ${TemplateStorageBucket}/container-signer/template.yaml
       Parameters:
@@ -61,7 +74,7 @@ Resources:
 
   CodeSigner:
     Type: AWS::CloudFormation::Stack
-    Condition: IsInitialAccount
+    Condition: InitialAccount
     Properties:
       TemplateURL: !Sub ${TemplateStorageBucket}/signer/template.yaml
       Parameters:
@@ -72,7 +85,7 @@ Resources:
     Properties:
       TemplateURL: !Sub ${TemplateStorageBucket}/grafana-metrics/template.yaml
       Parameters:
-        GrafanaEnvironment: !FindInMap [ Grafana, env, !Ref EnvironmentType, { DefaultValue: !FindInMap [ Grafana, env, default ] } ]
+        GrafanaEnvironment: !FindInMap [ Grafana, Env, !Ref EnvironmentType, { DefaultValue: !FindInMap [ Grafana, Env, default ] } ]
 
   # Setting up Grafana key rotation
   # https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3467509761/Grafana+key+rotation
@@ -83,7 +96,7 @@ Resources:
     Properties:
       TemplateURL: !Sub ${TemplateStorageBucket}/grafana-key-rotation/template.yaml
       Parameters:
-        GrafanaEnvironment: !FindInMap [ Grafana, env, !Ref EnvironmentType, { DefaultValue: !FindInMap [ Grafana, env, default ] } ]
+        GrafanaEnvironment: !FindInMap [ Grafana, Env, !Ref EnvironmentType, { DefaultValue: !FindInMap [ Grafana, Env, default ] } ]
         GrafanaKeySecretId: !Ref GrafanaKeySecretName
 
   SlackNotifications:
@@ -133,19 +146,22 @@ Resources:
 
 Outputs:
   GitHubIdentityProviderARN:
-    Condition: IsInitialProductionAccount
+    Condition: InitialProductionAccount
     Value: !GetAtt GitHubIdentityProvider.Outputs.GitHubIdentityProviderArn
   ContainerSigningKeyARN:
-    Condition: IsInitialProductionAccount
-    Value: !GetAtt ContainerSigner.Outputs.ContainerSignerKmsKeyArn
+    Condition: InitialAccount
+    Value: !If
+      - InitialProductionAccount
+      - !GetAtt ContainerSigner.Outputs.ContainerSignerKmsKeyArn
+      - !GetAtt DevelopmentContainerSigner.Outputs.ContainerSignerKmsKeyArn
   SigningProfileName:
-    Condition: IsInitialAccount
+    Condition: InitialAccount
     Value: !GetAtt CodeSigner.Outputs.SigningProfileName
   SigningProfileARN:
-    Condition: IsInitialAccount
+    Condition: InitialAccount
     Value: !GetAtt CodeSigner.Outputs.SigningProfileArn
   SigningProfileVersionARN:
-    Condition: IsInitialAccount
+    Condition: InitialAccount
     Value: !GetAtt CodeSigner.Outputs.SigningProfileVersionArn
   SlackNotificationsStackName:
     Value: !Select [ 1, !Split [ "/", !Ref SlackNotifications ] ]

--- a/infrastructure/dev/README.md
+++ b/infrastructure/dev/README.md
@@ -1,10 +1,11 @@
 # Developer stacks
 
-## Deploying
+### TL;DR
 
-Authenticate to AWS before deploying. The script checks that AWS credentials are present in the environment and the
-session is not expired. You may use the [gds-cli](https://github.com/alphagov/gds-cli) or any other method to set
-the necessary environment variables.
+Run `npm run deploy` to deploy and `npm run remote` to run a local frontend, or `npm run deploy admin-tool` to do it
+one command.
+
+## Deploying
 
 Deploy a backend component (e.g. `api`) with the default username prefix
 
@@ -31,6 +32,22 @@ Deploy the full stack set
 npm run deploy [prefix]
 ```
 
+### Passing SAM options
+
+Attach additional options to pass to the [SAM build/deploy script](../deploy-sam-stack.sh)
+
+```shell
+./deploy.sh [component] [prefix] --cached --parallel --no-confirm
+```
+
+When invoking with `npm` and passing options, the parameters need to be preceded by the `--` separator
+
+```shell
+npm run deploy [component] [prefix] -- [options]
+```
+
+You most likely should always use `-c -p -y` for fast builds and deploys.
+
 ## Running a local frontend against deployed backend stacks
 
 The script gets the export values from AWS based on the supplied prefix, and sets the environment variables before
@@ -54,16 +71,22 @@ Deploy and run
 npm run deploy admin-tool [prefix]
 ```
 
-## Passing SAM options
+## Listing and deleting stacks
 
-Attach additional options to pass to the [SAM build/deploy script](../deploy-sam-stack.sh)
+List all deployed stacks with the given or default prefix
 
 ```shell
-./deploy.sh api [prefix] --cached --parallel --no-confirm
+npm run list [prefix]
 ```
 
-When invoking with `npm` and passing options, the parameters need to be preceded by the `--` separator
+Delete all stacks with the given or default prefix
 
 ```shell
-npm run deploy -- [component] [prefix] [options]
+npm run delete [prefix]
+```
+
+Delete the specified component stacks with the given prefix
+
+```shell
+npm run delete prefix [components...]
 ```

--- a/infrastructure/dev/deploy.sh
+++ b/infrastructure/dev/deploy.sh
@@ -1,28 +1,66 @@
 #!/usr/bin/env bash
-# Deploy and run a local stack against an AWS backend
+# The "it just works" script to deploy backend stacks and run a local Admin Tool frontend against them
 cd "$(dirname "${BASH_SOURCE[0]}")"
+export AWS_DEFAULT_REGION=eu-west-2
 set -eu
 
-COMMANDS=(api cognito dynamodb all run admin-tool help)
-USER_NAME=$(../aws.sh get-user-name development)
+declare -A ENV=(
+  [SESSIONS_TABLE]=SessionsTableName
+  [API_BASE_URL]=APIBaseURL
+  [COGNITO_USER_POOL_ID]=CognitoUserPoolID
+  [COGNITO_CLIENT_ID]=CognitoUserPoolClientID
+)
+
+COMPONENTS=(cognito dynamodb api)
+DEPLOY_CMDS=("${COMPONENTS[@]}" all admin-tool)
+COMMANDS=("${DEPLOY_CMDS[@]}" run list delete help)
+
+../aws.sh check-current-account development &> /dev/null || eval "$(gds aws di-onboarding-development -e)"
+USER_NAME=$(../aws.sh get-user-name)
 LOG_PREFIX=/self-service/dev
 REPO_ROOT=$(pwd)/../..
 OPTION_REGEX="^--?.*"
 DEV_PREFIX=dev
 
 function help {
-  echo "deploy.sh [$(IFS="|" && echo "${COMMANDS[*]}")] [prefix] [SAM deploy options]" && exit
+  (IFS="|" && echo "deploy.sh [${COMMANDS[*]}] [prefix] [SAM deploy options]") && exit
 }
 
 function get-export {
-  jq --exit-status --raw-output --arg name "$1" '.[] | select(.Name | endswith($name)) | .Value' <<< "$exports" ||
-    echo "𝙭 Export '$1' not found" >&2
+  jq --exit-status --raw-output --arg name "$STACK_PREFIX-$1" '.[] | select(.Name == $name) | .Value' <<< "$exports"
 }
 
 function set-prefix {
-  [[ ${STACK_PREFIX:-} ]] && return
-  STACK_PREFIX=$(tr "." "-" <<< "$USER_NAME")
-  echo "Stack prefix not set; using the default prefix '$STACK_PREFIX'"
+  [[ ${STACK_PREFIX:-} ]] && return || STACK_PREFIX=${1:-}
+
+  if ! [[ ${STACK_PREFIX:-} ]]; then
+    STACK_PREFIX=$(tr "." "-" <<< "$USER_NAME")
+    echo "𝓲 Stack prefix not set; using the default prefix '$STACK_PREFIX'" >&2
+  fi
+
+  STACK_PREFIX=$DEV_PREFIX-$STACK_PREFIX
+}
+
+function get-env-vars {
+  exports=$(aws cloudformation list-exports --query "Exports[?starts_with(Name, '$STACK_PREFIX-')]")
+  [[ $exports == "[]" ]] && echo "No exports found for stack prefix '$STACK_PREFIX'" && exit
+
+  local var
+  for var in "${!ENV[@]}"; do
+    env+=("$var=$(get-export "${ENV[$var]}")") && continue
+    echo "𝙭 Export '${ENV[$var]}' not found" >&2 && return 1
+  done
+}
+
+function list {
+  aws cloudformation describe-stacks | (IFS="|" && jq --raw-output \
+    --arg regex "$STACK_PREFIX-(${OPTIONS[*]:-${COMPONENTS[*]}})" \
+    '.Stacks[] | select(.StackName | match($regex)) | .StackName')
+}
+
+function delete {
+  local stack
+  for stack in $(list); do sam delete --no-prompts --region $AWS_DEFAULT_REGION --stack-name "$stack"; done
 }
 
 function deploy-backend-component {
@@ -34,22 +72,17 @@ function deploy-backend-component {
 
   "$REPO_ROOT"/infrastructure/deploy-sam-stack.sh "${@:2}" "${OPTIONS[@]}" \
     --account development \
-    ${template:+--template "$template"} \
-    ${STACK_PREFIX:+--stack-name $DEV_PREFIX-$STACK_PREFIX-$component} \
+    ${template:+--template $template} \
+    ${STACK_PREFIX:+--stack-name $STACK_PREFIX-$component} \
     --tags sse:component="$component" sse:stack-type=dev sse:stack-role=application sse:owner="$USER_NAME" \
-    --params ${STACK_PREFIX:+ExportNamePrefix=$DEV_PREFIX-$STACK_PREFIX}
+    --params ${STACK_PREFIX:+ExportNamePrefix=$STACK_PREFIX}
 
-  popd > /dev//null
+  popd > /dev/null
 }
 
 function run {
-  [[ ${STACK_PREFIX:-} ]] || set-prefix
-  exports=$(aws cloudformation list-exports --query "Exports[?starts_with(Name, '$DEV_PREFIX-$STACK_PREFIX')]")
-  [[ $exports == "[]" ]] && echo "No exports found for stack prefix '$STACK_PREFIX'" && exit
-
-  COGNITO_USER_POOL_ID=$(get-export CognitoUserPoolID) COGNITO_CLIENT_ID=$(get-export CognitoUserPoolClientID) \
-  SESSIONS_TABLE=$(get-export SessionsTableName) API_BASE_URL=$(get-export APIBaseURL) \
-  COGNITO_CLIENT=CognitoClient LAMBDA_FACADE=LambdaFacade npm run dev
+  get-env-vars && (IFS=$'\n' && echo "${env[*]}") || exit
+  eval "${env[*]}" COGNITO_CLIENT=CognitoClient LAMBDA_FACADE=LambdaFacade npm run dev
 }
 
 function dynamodb {
@@ -72,12 +105,13 @@ function all {
 }
 
 function admin-tool {
-  deploy
+  all
   run
 }
 
 [[ ${COMMANDS[*]} =~ ${1:-} ]] && COMMAND=$1 && shift
-[[ ${1:--} =~ $OPTION_REGEX ]] || { STACK_PREFIX=$1 && shift; }
+[[ ${1:--} =~ $OPTION_REGEX ]] || { set-prefix "$1" && shift; }
+[[ ${DEPLOY_CMDS[*]} =~ ${COMMAND:=all} ]] || set-prefix
 
 OPTIONS=("$@")
-${COMMAND:-all}
+$COMMAND

--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -119,7 +119,8 @@ Resources:
               ArnLike:
                 aws:SourceArn: !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:*
       Policies:
-        - PolicyName: DynamoDbActions
+        # https://github.com/ca98am79/connect-dynamodb#iam-permissions
+        - PolicyName: SessionStorageTableAccess
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -133,7 +134,7 @@ Resources:
                   - dynamodb:CreateTable
                   - dynamodb:PutItem
                 Resource:
-                  Fn::ImportValue: !Sub ${ ExportNamePrefix }-AdminToolSessionsTableArn
+                  Fn::ImportValue: !Sub ${ExportNamePrefix}-SessionsTableArn
 
   FrontendAppTaskDefinition:
     Type: AWS::ECS::TaskDefinition

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "dev": "npm run dev -w express",
     "aws": "npm run remote --",
     "remote": "infrastructure/dev/deploy.sh run",
+    "delete": "infrastructure/dev/deploy.sh delete",
+    "list": "infrastructure/dev/deploy.sh list",
+    "creds": "infrastructure/aws.sh",
     "test": "jest --silent",
     "cucumber": "npm run cucumber -w acceptance-tests --"
   },


### PR DESCRIPTION
**Update developer deployment script**
_"It just works"_

Make it easier to use the script to deploy and manage local stacks.

🆕 Add new commands to list and delete stack sets
🆕 Automatically authenticate to AWS if credentials are not present in the environment
🆕 Export the default AWS region to the environment
- Update parameters and environment variables

**Update pipeline and support stacks**

- Add container signer to the development account
- Don't pass allowed accounts in development, since it has no accounts it promotes to
- Pass in the initial account param directly
- Add a container signer in the development account
  A separate resource is needed since in the dev account we deploy our own OIDC provider stack, which the container signer stack cannot depend on. The conditions select the appropriate version and its outputs.
- Include environment name in pipeline names
  The pipeline resources can no include the account name so it would show up in Slack notifications.
  The new `PipelineEnvironentNameEnabled` param triggers the change (the typo comes from the source template)

**Update the script to empty buckets for deletion**

The script is now smarter and handles large buckets and can run in a loop whilst the delete job runs. The script runs in the background, keeps the buckets empty and automatically stops when all the buckets have been deleted.

The script now lists all stacks if no params have been passed and takes a param to select buckets for deletion.

---

- Add ECR scanning stack to the support stacks template
  Add a param for the dev notification email