### PR TITLE
Allow prod and nonprod to have different allowed email domins

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -20,7 +20,9 @@ jobs:
       - name: Run checkov
         uses: alphagov/di-github-actions/code-quality/run-checkov@5dacba941def444d69f02843feaebed79b5fca51
         with:
-          skip-checks: CKV_SECRET_6
+          skip-checks:
+            CKV_SECRET_6
+            CKV_SECRET_9
 
   check-shell-scripts:
     name: Shell scripts

--- a/acceptance-tests/features/account.feature
+++ b/acceptance-tests/features/account.feature
@@ -2,7 +2,7 @@ Feature: A page where users can view and change the details associated with thei
 
   Background:
     Given the user is on the "/sign-in" page
-    And they submit the email "registered@gds.gov.uk"
+    And they submit the email "registered@test.gov.uk"
     And they submit a valid password
     And they submit a correct security code
     And they should be redirected to a page with the title "Your services - GOV.UK One Login"

--- a/acceptance-tests/features/clients.feature
+++ b/acceptance-tests/features/clients.feature
@@ -2,7 +2,7 @@ Feature: Users can update clients
 
   Background:
     Given the user is on the "/sign-in" page
-    And they submit the email "registered@gds.gov.uk"
+    And they submit the email "registered@test.gov.uk"
     And they submit a valid password
     And they submit a correct security code
     Then they should be redirected to a page with the title "Your services - GOV.UK One Login"

--- a/acceptance-tests/features/register.feature
+++ b/acceptance-tests/features/register.feature
@@ -24,10 +24,8 @@ Feature: Users can sign up to the self-service experience
 
       Examples:
         | email                                     |
-        | "test-user@department.gov.uk"             |
-        | "test-user@digital.cabinet-office.gov.uk" |
-        | "test-user@highwaysengland.co.uk"         |
-        | "test-user@socialworkengland.org.uk"      |
+        | "test-user@test.gov.uk" |
+        | "test-user@digital.cabinet-office.gov.uk"      |
 
     Scenario Outline: User tries to register with a verboten email address
 
@@ -41,46 +39,46 @@ Feature: Users can sign up to the self-service experience
 
   Rule: The user tries to submit an email address that is already registered
     Scenario: The user is offered to sign in and signs in instead
-      When they submit the email "inuse@foo.gov.uk"
+      When they submit the email "inuse@test.gov.uk"
       Then they should be redirected to the "/register/account-exists" page
-      And they should see the text "An account already exists with the email address inuse@foo.gov.uk"
+      And they should see the text "An account already exists with the email address inuse@test.gov.uk"
       When they submit a valid password
       And they submit a correct security code
       Then they should be redirected to a page with the path starting with "/services"
       And they should see the text "Your services"
 
     Scenario: The user is offered to sign in, tries to sign in and enters an empty password
-      When they submit the email "inuse@foo.gov.uk"
+      When they submit the email "inuse@test.gov.uk"
       Then they should be redirected to the "/register/account-exists" page
-      And they should see the text "An account already exists with the email address inuse@foo.gov.uk"
+      And they should see the text "An account already exists with the email address inuse@test.gov.uk"
       When they submit the password ""
       Then the error message "Enter your password" must be displayed for the password field
 
     Scenario: The user is offered to sign in, tries to sign in and enters the wrong password
-      When they submit the email "inuse-password-will-be-wrong@foo.gov.uk"
+      When they submit the email "inuse-password-will-be-wrong@test.gov.uk"
       Then they should be redirected to the "/register/account-exists" page
-      And they should see the text "An account already exists with the email address inuse-password-will-be-wrong@foo.gov.uk"
+      And they should see the text "An account already exists with the email address inuse-password-will-be-wrong@test.gov.uk"
       When they submit the password "WrongPa$$word"
       Then the error message "Incorrect password" must be displayed for the password field
 
   Rule: The user tries to verify email security code when creating an account
     Background:
-      Given they submit the email "registering-successfully@gds.gov.uk"
+      Given they submit the email "registering-successfully@test.gov.uk"
       Then they should be redirected to the "/register/enter-email-code" page
 
     Scenario: The user submits an empty security code
       When they click the Submit button
       Then the error message "Enter the 6 digit security code" must be displayed for the security code field
-      And they should see the text "We have sent an email to: registering-successfully@gds.gov.uk"
+      And they should see the text "We have sent an email to: registering-successfully@test.gov.uk"
 
     Scenario: The user enters a security code in an incorrect format
       When they submit the security code "12345A"
       Then the error message "Your security code should only include numbers" must be displayed for the security code field
-      And they should see the text "We have sent an email to: registering-successfully@gds.gov.uk"
+      And they should see the text "We have sent an email to: registering-successfully@test.gov.uk"
 
   Rule: The user does not receive their email security code and clicks 'Not received an email?' link
     Background:
-      When they submit the email "registering-successfully@gds.gov.uk"
+      When they submit the email "registering-successfully@test.gov.uk"
       Then they should be redirected to the "/register/enter-email-code" page
       And they click on the "Not received an email?" link
       Then they should be redirected to the "/register/resend-email-code" page
@@ -99,7 +97,7 @@ Feature: Users can sign up to the self-service experience
 
   Rule: The user tries to set a password when creating an account
     Background:
-      Given they submit the email "registering-successfully@gds.gov.uk"
+      Given they submit the email "registering-successfully@test.gov.uk"
       And they submit a correct security code
       Then they should be redirected to the "/register/create-password" page
 
@@ -129,7 +127,7 @@ Feature: Users can sign up to the self-service experience
 
   Rule: The user tries to add a phone number when creating an account
     Background:
-      Given they submit the email "registering-successfully@gds.gov.uk"
+      Given they submit the email "registering-successfully@test.gov.uk"
       And they submit a correct security code
       And they submit a valid password
       Then they should be redirected to the "/register/enter-phone-number" page
@@ -148,7 +146,7 @@ Feature: Users can sign up to the self-service experience
 
   Rule: The user tries to verify the SMS security code when creating an account
     Background:
-      Given they submit the email "registering-successfully@gds.gov.uk"
+      Given they submit the email "registering-successfully@test.gov.uk"
       And they submit a correct security code
       And they submit a valid password
       And they submit a valid mobile phone number
@@ -216,7 +214,7 @@ Feature: Users can sign up to the self-service experience
 
   Rule: The user tries to add a service when creating an account
     Background:
-      Given they submit the email "registering-successfully@gds.gov.uk"
+      Given they submit the email "registering-successfully@test.gov.uk"
       And they submit a correct security code
       And they submit a valid password
       And they submit a valid mobile phone number

--- a/acceptance-tests/features/services/joining-private-beta.feature
+++ b/acceptance-tests/features/services/joining-private-beta.feature
@@ -2,7 +2,7 @@ Feature: Joining private beta
 
   Background:
     Given the user is on the "/sign-in" page
-    And they submit the email "registered@gds.gov.uk"
+    And they submit the email "registered@test.gov.uk"
     And they submit a valid password
     And they submit a correct security code
     Then they should be redirected to a page with the title "Your services - GOV.UK One Login"
@@ -27,7 +27,7 @@ Feature: Joining private beta
       Then the error message "Enter your department" must be displayed for the department name field
 
     Scenario: The user’s data is replayed to them
-      Then they should see the text "registered@gds.gov.uk"
+      Then they should see the text "registered@test.gov.uk"
       Then they should see the text "Test Service"
 
     Scenario: The user submits their private beta request

--- a/acceptance-tests/features/services/update-service-name.feature
+++ b/acceptance-tests/features/services/update-service-name.feature
@@ -2,7 +2,7 @@ Feature: Change your service name
 
   Background:
     Given the user is on the "/sign-in" page
-    And they submit the email "registered@gds.gov.uk"
+    And they submit the email "registered@test.gov.uk"
     And they submit a valid password
     And they submit a correct security code
     Then they should be redirected to a page with the title "Your services - GOV.UK One Login"

--- a/acceptance-tests/features/sign-in.feature
+++ b/acceptance-tests/features/sign-in.feature
@@ -14,25 +14,25 @@ Feature: Users can sign in to the self-service experience
 
   Rule: The user tries to submit a password
     Scenario: User doesn't enter any characters into the password field
-      When they submit the email "registered@gds.gov.uk"
+      When they submit the email "registered@test.gov.uk"
       Then they should be redirected to the "/sign-in/enter-password" page
       When they submit the password ""
       Then the error message "Enter your password" must be displayed for the password field
 
     Scenario: User enters an invalid password
-      When they submit the email "password-will-be-wrong@stub.gov.uk"
+      When they submit the email "password-will-be-wrong@test.gov.uk"
       Then they should see the text "Enter your password"
       When they submit the password "Invalid-Password"
       Then the error message "Incorrect password" must be displayed for the password field
 
     Scenario: The user tries to log in and submits registered email but enters wrong password
-      When they submit the email "password-will-be-wrong@stub.gov.uk"
+      When they submit the email "password-will-be-wrong@test.gov.uk"
       Then they should see the text "Enter your password"
       When they submit the password "WrongPa$$word"
       Then the error message "Incorrect password" must be displayed for the password field
 
     Scenario: The user wants to see or hide their password as they type it
-      When they submit the email "registered@gds.gov.uk"
+      When they submit the email "registered@test.gov.uk"
       Then they should see the text "Enter your password"
       When they toggle the "Show" link on the field "password"
       And they enter the password "PasswordIsShown"
@@ -44,13 +44,13 @@ Feature: Users can sign in to the self-service experience
 
   Rule: The user tries to sign in with account which is not registered
     Scenario: The user submits email and password but account is not registered
-      When they submit the email "not-registered@gds.gov.uk"
+      When they submit the email "not-registered@test.gov.uk"
       When they submit a valid password
       Then they should be redirected to the "/sign-in/account-not-found" page
 
   Rule: The user tries to reset their password
     Background:
-      When they submit the email "registered@gds.gov.uk"
+      When they submit the email "registered@test.gov.uk"
       Then they click on the "Forgot your password?" link
       Then they should be redirected to the "/sign-in/forgot-password" page
       Then they click the Continue button

--- a/acceptance-tests/support/steps/shared-steps.ts
+++ b/acceptance-tests/support/steps/shared-steps.ts
@@ -133,7 +133,7 @@ When("they enter {string} into the {string} field", async function (text: string
 });
 
 When("they click on the forgot password link in their email", async function () {
-    const path = "/sign-in/forgot-password/create-new-password?loginName=registered@gds.gov.uk&confirmationCode=123456";
+    const path = "/sign-in/forgot-password/create-new-password?loginName=registered@test.gov.uk&confirmationCode=123456";
     await this.goToPath(path);
 });
 

--- a/express/resources/allowed-test-domains.txt
+++ b/express/resources/allowed-test-domains.txt
@@ -1,0 +1,3 @@
+# Note: never place plain .gov.uk in this list as it opens up to anyone to come in
+digital.cabinet-office.gov.uk
+test.gov.uk

--- a/express/src/config/environment.ts
+++ b/express/src/config/environment.ts
@@ -4,6 +4,8 @@ export const showTestBanner = process.env.TEST_BANNER == "true";
 export const googleTagId = process.env.GOOGLE_TAG_ID;
 export const region = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION;
 
+export const allowedEmailDomainsSource = process.env.ALLOWED_EMAIL_DOMAINS_SOURCE || "allowed-test-domains";
+
 export const sessionSecret = process.env.SESSION_SECRET;
 
 export const cognito = {

--- a/express/src/config/resources.ts
+++ b/express/src/config/resources.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import {allowedEmailDomainsSource} from "./environment";
 
 const baseDir = path.join(__dirname, "../..");
 const resourcesDir = path.join(baseDir, "resources");
@@ -7,7 +8,7 @@ export const views = path.join(baseDir, "src/views");
 
 export const resources = {
     commonPasswords: path.join(resourcesDir, "common-passwords.txt"),
-    validDomains: path.join(resourcesDir, "allowed-email-domains.txt")
+    validDomains: path.join(resourcesDir, allowedEmailDomainsSource.concat(".txt"))
 };
 
 export const distribution = {

--- a/express/src/lib/validators/allowed-email-domains.ts
+++ b/express/src/lib/validators/allowed-email-domains.ts
@@ -16,5 +16,8 @@ function getEmailDomain(email: string) {
 async function loadAllowedEmailDomains() {
     console.log("Loading allowed email domains....");
     const domains = await readFile(resources.validDomains, {encoding: "utf8"});
-    return domains.trim().split("\n");
+    return domains
+        .trim()
+        .split("\n")
+        .filter(line => !line.startsWith("#"));
 }

--- a/express/src/routes/testing.ts
+++ b/express/src/routes/testing.ts
@@ -152,7 +152,7 @@ router.get("/client-details-mocked", (req, res) => {
 router.get("/change-email-address", (req, res) => {
     res.render("test/change-email-address.njk", {
         values: {
-            emailAddress: "your.email@digital.cabinet-office.gov.uk"
+            emailAddress: "your.email@test.gov.uk"
         }
     });
 });
@@ -188,7 +188,7 @@ router.post("/check-email-visual-test", async (req, res) => {
 //// Testing route to redirect to account page success screen
 router.get("/account-success-screen-test", (req, res) => {
     res.render("account/account.njk", {
-        emailAddress: "your.email@digital.cabinet-office.gov.uk",
+        emailAddress: "your.email@test.gov.uk",
         mobilePhoneNumber: "07123456789",
         passwordLastChanged: "Last changed 1 month ago",
         updatedField: "email address"
@@ -208,7 +208,7 @@ router.get("/private-beta-submitted", (req, res) => {
 router.get("/security-check-change-number", (req, res) => {
     res.render("test/security-check-change-number.njk", {
         values: {
-            emailAddress: "your.email@digital.cabinet-office.gov.uk"
+            emailAddress: "your.email@test.gov.uk"
         }
     });
 });
@@ -217,7 +217,7 @@ router.post("/security-check-change-number", async (req, res) => {
     if (req.body.securityCode === "") {
         res.render("test/security-check-change-number.njk", {
             values: {
-                emailAddress: "your.email@digital.cabinet-office.gov.uk"
+                emailAddress: "your.email@test.gov.uk"
             },
             errorMessages: {
                 securityCode: "Enter the security code"
@@ -318,7 +318,7 @@ router.get("/team-members/:serviceId/:selfServiceClientId/:clientId", (req, res)
             {
                 userPersonalName: "Courtney Toth",
                 isCurrentUser: true,
-                userEmail: "courtney.toth@gov.uk.cabinet-office.gov.uk",
+                userEmail: "courtney.toth@test.gov.uk",
                 permissions: {
                     "Manage team members": true,
                     "Change integration client details": true,
@@ -329,7 +329,7 @@ router.get("/team-members/:serviceId/:selfServiceClientId/:clientId", (req, res)
             {
                 userPersonalName: "Beth Walton",
                 isCurrentUser: false,
-                userEmail: "beth.walton@gov.cabinet-office.gov.uk",
+                userEmail: "beth.walton@test.gov.uk",
                 permissions: {
                     "Manage team members": true,
                     "Change integration client details": false,
@@ -340,7 +340,7 @@ router.get("/team-members/:serviceId/:selfServiceClientId/:clientId", (req, res)
             {
                 userPersonalName: "Onyebuchi Hathway",
                 isCurrentUser: false,
-                userEmail: "onyebuchi.hathwayk@gov.cabinet-office.gov.uk",
+                userEmail: "onyebuchi.hathwayk@test.gov.uk",
                 permissions: {
                     "Manage team members": false,
                     "Change integration client details": true,
@@ -351,7 +351,7 @@ router.get("/team-members/:serviceId/:selfServiceClientId/:clientId", (req, res)
             {
                 userPersonalName: "Robin Jöllenbeck",
                 isCurrentUser: false,
-                userEmail: "robin.jöllenbeck@gov.cabinet-office.gov.uk",
+                userEmail: "robin.jöllenbeck@test.gov.uk",
                 permissions: {
                     "Manage team members": false,
                     "Change integration client details": true,
@@ -362,7 +362,7 @@ router.get("/team-members/:serviceId/:selfServiceClientId/:clientId", (req, res)
             {
                 userPersonalName: "Wallace Martinez",
                 isCurrentUser: false,
-                userEmail: "wallace.martinez@gov.cabinet-office.gov.uk",
+                userEmail: "wallace.martinez@test.gov.uk",
                 permissions: {
                     "Manage team members": false,
                     "Change integration client details": false,
@@ -373,7 +373,7 @@ router.get("/team-members/:serviceId/:selfServiceClientId/:clientId", (req, res)
             {
                 userPersonalName: "Zawadi Cameron",
                 isCurrentUser: false,
-                userEmail: "zawadi.cameron@gov.cabinet-office.gov.uk",
+                userEmail: "zawadi.cameron@test.gov.uk",
                 permissions: {
                     "Manage team members": false,
                     "Change integration client details": true,
@@ -384,7 +384,7 @@ router.get("/team-members/:serviceId/:selfServiceClientId/:clientId", (req, res)
         ],
         pendingInvitations: [
             {
-                userEmail: "james.pirot@gov.cabinet-office.gov.uk",
+                userEmail: "james.pirot@test.gov.uk",
                 permissions: {
                     "Manage team members": false,
                     "Change integration client details": false,
@@ -393,7 +393,7 @@ router.get("/team-members/:serviceId/:selfServiceClientId/:clientId", (req, res)
                 }
             },
             {
-                userEmail: "leighton.brey@gov.cabinet-office.gov.uk",
+                userEmail: "leighton.brey@test.gov.uk",
                 permissions: {
                     "Manage team members": true,
                     "Change integration client details": true,
@@ -420,7 +420,7 @@ router.post("/invite-team-member", validateEmail("test/invite-team-member.njk"),
 router.get("/invitation-sent", (req, res) => {
     res.render("test/invitation-sent.njk", {
         serviceName: "Frontend Test Service",
-        userEmail: "james.pirot@digital.cabinet-office.gov.uk"
+        userEmail: "james.pirot@test.gov.uk"
     });
 });
 

--- a/express/src/services/lambda-facade/StubLambdaFacade.ts
+++ b/express/src/services/lambda-facade/StubLambdaFacade.ts
@@ -85,7 +85,7 @@ export default class StubLambdaFacade implements LambdaFacadeInterface {
                         sk: {S: "user#29ad13ba-ceca-4141-95d7-e376b0ca4688"},
                         role: {S: "admin"},
                         pk: {S: "service#277619fe-c056-45be-bc2a-43310613913c"},
-                        data: {S: "john.watts@digital.cabinet-office.gov.uk"}
+                        data: {S: "john.watts@test.gov.uk"}
                     }
                 ]
             }
@@ -100,7 +100,7 @@ export default class StubLambdaFacade implements LambdaFacadeInterface {
                         service_name: {S: this.serviceName},
                         post_logout_redirect_uris: convertToAttr(this.postLogoutRedirectUris),
                         subject_type: {S: "pairwise"},
-                        contacts: {L: [{S: "john.watts@digital.cabinet-office.gov.uk"}, {S: "onboarding@digital.cabinet-office.gov.uk"}]},
+                        contacts: {L: [{S: "john.watts@test.gov.uk"}, {S: "onboarding@test.gov.uk"}]},
                         public_key: {
                             S: this.publicKey
                         },

--- a/express/stubs/stubs-config.json
+++ b/express/stubs/stubs-config.json
@@ -2,17 +2,17 @@
   "createUser": [
     {
       "parameter": "email",
-      "value": "inuse@foo.gov.uk",
+      "value": "inuse@test.gov.uk",
       "throw": "UsernameExistsException"
     },
     {
       "parameter": "email",
-      "value": "inuse-password-will-be-wrong@foo.gov.uk",
+      "value": "inuse-password-will-be-wrong@test.gov.uk",
       "throw": "UsernameExistsException"
     },
     {
       "parameter": "email",
-      "value": "returnsomething@foo.gov.uk",
+      "value": "returnsomething@test.gov.uk",
       "return": {
         "$metadata": {
           "foo": "bar"
@@ -23,7 +23,7 @@
   "login": [
     {
       "parameter": "email",
-      "value": "registered@gds.gov.uk",
+      "value": "registered@test.gov.uk",
       "return": {
         "$metadata": {
           "httpStatusCode": 200,
@@ -45,7 +45,7 @@
     },
     {
       "parameter": "email",
-      "value": "inuse@foo.gov.uk",
+      "value": "inuse@test.gov.uk",
       "return": {
         "$metadata": {
           "httpStatusCode": 200,
@@ -67,24 +67,24 @@
     },
     {
       "parameter": "email",
-      "value": "inuse-password-will-be-wrong@foo.gov.uk",
+      "value": "inuse-password-will-be-wrong@test.gov.uk",
       "throw": "NotAuthorizedException"
     },
     {
       "parameter": "email",
-      "value": "registering-successfully@gds.gov.uk",
+      "value": "registering-successfully@test.gov.uk",
       "return": {
         "Session": "Some or other arbitrary non-null value"
       }
     },
     {
       "parameter": "email",
-      "value": "password-will-be-wrong@stub.gov.uk",
+      "value": "password-will-be-wrong@test.gov.uk",
       "throw": "NotAuthorizedException"
     },
     {
       "parameter": "email",
-      "value": "not-registered@gds.gov.uk",
+      "value": "not-registered@test.gov.uk",
       "throw": "UserNotFoundException"
     }
   ],

--- a/express/tests/lib/validators/email-validator.test.ts
+++ b/express/tests/lib/validators/email-validator.test.ts
@@ -22,7 +22,7 @@ describe("Verify email addresses", () => {
 
     describe("Verify an email address is formatted correctly", () => {
         it("Accept an RFC822 compliant email address", async () => {
-            expect((await validateEmail("an_Email+modification@some.domain.gov.uk")).isValid).toBe(true);
+            expect((await validateEmail("an_Email+modification@test.gov.uk")).isValid).toBe(true);
         });
 
         it("Reject an email without the @ symbol", async () => {


### PR DESCRIPTION
Set the allowed emails domains source file in the environment, with default to a non-prod version. For consistency refactor the common password file for the same pattern, but currently no need for non-prod version.