### PR TITLE
SSE-2638: Add an option to make the backend API private

### DIFF
--- a/backend/api/api.template.yml
+++ b/backend/api/api.template.yml
@@ -1,8 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: DI Self-Service API
-Transform:
-  - AWS::Serverless-2016-10-31
-  - AWS::LanguageExtensions
+Transform: [ AWS::LanguageExtensions, AWS::Serverless-2016-10-31 ]
 
 Parameters:
   AuthRegistrationBaseUrl:
@@ -23,6 +21,10 @@ Parameters:
     AllowedPattern: ^.*[^-]$
     Default: self-service
     Description: A unique prefix to identify the deployment; used when importing or exporting values from related stacks
+  PrivateAPI:
+    Type: String
+    AllowedValues: [ Yes, No ]
+    Default: Yes
   PermissionsBoundary:
     Type: String
     Default: ""
@@ -33,6 +35,7 @@ Parameters:
 Conditions:
   UseCodeSigning: !Not [ !Equals [ !Ref CodeSigningConfigArn, "" ] ]
   UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundary, "" ] ]
+  PrivateAPI: !Equals [ !Ref PrivateAPI, Yes ]
 
 Globals:
   Function:
@@ -45,32 +48,66 @@ Globals:
 
 Resources:
 
-  SelfServiceApi:
-    Type: AWS::Serverless::HttpApi
+  # https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-apis.html
+  API:
+    # checkov:skip=CKV_AWS_120:Ensure API Gateway caching is enabled
+    Type: AWS::Serverless::Api
     Properties:
-      FailOnWarnings: true
+      Name: !Sub ${DeploymentName}-api
       StageName: self-service-api
-      AccessLogSettings:
-        DestinationArn: !GetAtt HttpApiLogGroup.Arn
+      TracingEnabled: true
+      FailOnWarnings: true
+      OpenApiVersion: 3.0.1
+      Auth:
+        ResourcePolicy: !If
+          - PrivateAPI
+          - # https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-resource-policies-examples.html#apigateway-resource-policies-source-vpc-example
+            CustomStatements:
+              - Effect: Allow
+                Resource: execute-api:/*
+                Action: execute-api:Invoke
+                Principal: "*"
+                Condition:
+                  StringEquals:
+                    aws:SourceVpce:
+                      Fn::ImportValue: VPC-ExecuteAPIGatewayEndpointID
+          - !Ref AWS::NoValue
+      EndpointConfiguration:
+        Type: !If [ PrivateAPI, PRIVATE, !Ref AWS::NoValue ]
+        VpcEndpointIds: !If [ PrivateAPI, Fn::ImportValue: VPC-ExecuteAPIGatewayEndpointID, !Ref AWS::NoValue ]
+      MethodSettings:
+        - HttpMethod: "*"
+          ResourcePath: /*
+          LoggingLevel: INFO
+          MetricsEnabled: true
+      AccessLogSetting:
+        DestinationArn: !GetAtt APIAccessLogsGroup.Arn
         Format:
           Fn::ToJsonString:
-            requestId: $context.requestId
-            ip: $context.identity.sourceIp
-            requestTime: $context.requestTime
-            httpMethod: $context.httpMethod
-            path: $context.path"
-            routeKey: $context.routeKey
+            path: $context.path
             status: $context.status
             protocol: $context.protocol
+            routeKey: $context.routeKey
+            requestId: $context.requestId
+            requestTime: $context.requestTime
+            httpMethod: $context.httpMethod
             responseLength: $context.responseLength
+            extendedRequestId: $context.extendedRequestId
+
+  APIAccessLogsGroup:
+    # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/api
+      RetentionInDays: 14
 
   #--- Users ---#
 
   GetUserFunction:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -81,25 +118,25 @@ Resources:
       CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
       Policies:
         - DynamoDBCrudPolicy:
-            TableName: 
+            TableName:
               Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
       Environment:
         Variables:
-          TABLE: 
-              Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
+          TABLE:
+            Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
       Events:
         Api:
-          Type: HttpApi
+          Type: Api
           Properties:
-            ApiId: !Ref SelfServiceApi
+            RestApiId: !Ref API
             Path: /get-user
             Method: POST
 
   PutUserFunction:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -110,25 +147,25 @@ Resources:
       CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
       Policies:
         - DynamoDBCrudPolicy:
-            TableName: 
+            TableName:
               Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
       Environment:
         Variables:
-          TABLE: 
-              Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
+          TABLE:
+            Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
       Events:
         Api:
-          Type: HttpApi
+          Type: Api
           Properties:
-            ApiId: !Ref SelfServiceApi
+            RestApiId: !Ref API
             Path: /put-user
             Method: POST
 
   UpdateUserFunction:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -140,27 +177,27 @@ Resources:
       CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
       Policies:
         - DynamoDBCrudPolicy:
-            TableName: 
+            TableName:
               Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
       Environment:
         Variables:
-          TABLE: 
-              Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
+          TABLE:
+            Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
       Events:
         Api:
-          Type: HttpApi
+          Type: Api
           Properties:
-            ApiId: !Ref SelfServiceApi
+            RestApiId: !Ref API
             Path: /update-user
             Method: POST
 
   #--- Services ---#
 
   GetServicesFunction:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -176,20 +213,20 @@ Resources:
       Environment:
         Variables:
           TABLE:
-              Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
+            Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
       Events:
         Api:
-          Type: HttpApi
+          Type: Api
           Properties:
-            ApiId: !Ref SelfServiceApi
+            RestApiId: !Ref API
             Path: /get-services/{userId}
             Method: GET
 
   PutServiceFunction:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -204,16 +241,16 @@ Resources:
               Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
       Environment:
         Variables:
-          TABLE: 
-              Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
+          TABLE:
+            Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
 
   #--- Service clients ---#
 
   GetServiceClientsFunction:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -224,25 +261,25 @@ Resources:
       CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
       Policies:
         - DynamoDBCrudPolicy:
-            TableName: 
+            TableName:
               Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
       Environment:
         Variables:
-          TABLE: 
-              Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
+          TABLE:
+            Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
       Events:
         Api:
-          Type: HttpApi
+          Type: Api
           Properties:
-            ApiId: !Ref SelfServiceApi
+            RestApiId: !Ref API
             Path: /get-service-clients/{serviceId}
             Method: GET
 
   PutServiceClientFunction:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -253,18 +290,18 @@ Resources:
       CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
       Policies:
         - DynamoDBCrudPolicy:
-            TableName: 
+            TableName:
               Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
       Environment:
         Variables:
-          TABLE: 
-              Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
+          TABLE:
+            Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
 
   UpdateServiceClientFunction:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -275,20 +312,20 @@ Resources:
       CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
       Policies:
         - DynamoDBCrudPolicy:
-            TableName: 
+            TableName:
               Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
       Environment:
         Variables:
-          TABLE: 
-              Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
+          TABLE:
+            Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
 
   #--- Service users ---#
 
   PutServiceUserFunction:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -299,20 +336,20 @@ Resources:
       CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
       Policies:
         - DynamoDBCrudPolicy:
-            TableName: 
+            TableName:
               Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
       Environment:
         Variables:
           TABLE:
-              Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
+            Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-DataTableName
 
   #--- Auth clients ---#
 
   RegisterAuthClientFunction:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -328,10 +365,10 @@ Resources:
           AUTH_API_KEY: "{{resolve:secretsmanager:/self-service/api/auth-api-key}}"
 
   UpdateAuthClientFunction:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -349,10 +386,10 @@ Resources:
   #--- Step Functions ---#
 
   NewServiceHandler:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -372,17 +409,17 @@ Resources:
             Resource: !Ref NewServiceStepFunction
       Events:
         Api:
-          Type: HttpApi
+          Type: Api
           Properties:
-            ApiId: !Ref SelfServiceApi
+            RestApiId: !Ref API
             Path: /new-service
             Method: POST
 
   NewClientHandler:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -402,17 +439,17 @@ Resources:
             Resource: !Ref NewClientStepFunction
       Events:
         Api:
-          Type: HttpApi
+          Type: Api
           Properties:
-            ApiId: !Ref SelfServiceApi
+            RestApiId: !Ref API
             Path: /new-client
             Method: POST
 
   UpdateClientHandler:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -432,9 +469,9 @@ Resources:
             Resource: !Ref UpdateClientStepFunction
       Events:
         Api:
-          Type: HttpApi
+          Type: Api
           Properties:
-            ApiId: !Ref SelfServiceApi
+            RestApiId: !Ref API
             Path: /update-client
             Method: POST
 
@@ -530,25 +567,19 @@ Resources:
         UpdateServiceClientFunctionArn: !GetAtt UpdateServiceClientFunction.Arn
 
   StepFunctionsLogGroup:
-    # checkov:skip=CKV_AWS_158: "Ensure that CloudWatch Log Group is encrypted by KMS"
+    # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/api/step-functions
       RetentionInDays: 14
 
-  HttpApiLogGroup:
-    # checkov:skip=CKV_AWS_158: "Ensure that CloudWatch Log Group is encrypted by KMS"
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub ${LogGroupPrefix}/http-api/${AWS::StackName}
-      RetentionInDays: 14
   #--- Notifications ---#
 
   PrivateBetaNotificationFunction:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -566,26 +597,32 @@ Resources:
             TopicName: !GetAtt NotificationsSnsTopic.TopicName
       Events:
         Api:
-          Type: HttpApi
+          Type: Api
           Properties:
-            ApiId: !Ref SelfServiceApi
+            RestApiId: !Ref API
             Path: /send-private-beta-request-notification
             Method: POST
 
   NotificationsSnsTopic:
     Type: AWS::SNS::Topic
     Properties:
-      KmsMasterKeyId: "alias/aws/sns"
-      DisplayName: DI Admin Tool
+      DisplayName: DI Admin Tool Internal
       TopicName: !Sub ${DeploymentName}-internal-notifications
+      KmsMasterKeyId: alias/aws/sns
       Subscription:
         - Protocol: email
           Endpoint: !Ref NotificationEmail
 
 Outputs:
-  # SAM Serverless Function implicit API resources
+  # SAM Serverless Function implicit API resources | Invoking private APIs
   # https://github.com/aws/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
+  # https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-api-test-invoke-url.html#apigateway-private-api-route53-alias
   APIBaseURL:
-    Value: !Sub ${SelfServiceApi.ApiEndpoint}/${SelfServiceApi.Stage}
+    Value: !Sub
+      - https://${EndpointID}.execute-api.${AWS::Region}.amazonaws.com/${API.Stage}
+      - EndpointID: !Join
+          - "-"
+          - - !Ref API
+            - !If [ PrivateAPI, Fn::ImportValue: VPC-ExecuteAPIGatewayEndpointID, !Ref AWS::NoValue ]
     Export:
       Name: !Sub ${DeploymentName}-API-BaseURL

--- a/backend/cognito/cognito.template.yml
+++ b/backend/cognito/cognito.template.yml
@@ -18,6 +18,12 @@ Parameters:
     AllowedPattern: ^.*[^-]$
     Default: self-service
     Description: A unique prefix to identify the deployment; used when importing or exporting values from related stacks
+  EmailSenderID:
+    Type: String
+    Default: GOV.UK One Login
+  ProductName:
+    Type: String
+    Default: GOV.UK One Login admin tool
   PermissionsBoundary:
     Type: String
     Default: ""
@@ -41,7 +47,7 @@ Globals:
 Resources:
   # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-root-enable-iam
   SecurityCodeEncryptionKey:
-    # checkov:skip=CKV_AWS_7: "Ensure rotation for customer created CMKs is enabled"
+    # checkov:skip=CKV_AWS_7:Ensure rotation for customer created CMKs is enabled
     Type: AWS::KMS::Key
     Properties:
       KeyPolicy:
@@ -49,15 +55,15 @@ Resources:
         Statement:
           - Sid: Enable IAM User Permissions
             Effect: Allow
-            Principal:
-              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
-            Action: kms:*
             Resource: "*"
+            Action: kms:*
+            Principal:
+              AWS: !Ref AWS::AccountId
           - Effect: Allow
+            Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
+            Action: kms:CreateGrant
             Principal:
               Service: cognito-idp.amazonaws.com
-            Action: kms:CreateGrant
-            Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
             Condition:
               StringEquals:
                 aws:SourceAccount: !Ref AWS::AccountId
@@ -65,10 +71,10 @@ Resources:
                 aws:SourceArn: !Sub arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/*
 
   SendPasswordChangedEmailFunction:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -80,7 +86,7 @@ Resources:
       CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
       Environment:
         Variables:
-          FROM_ADDRESS: !Sub [ "admin-tool@${emailDomain}", { emailDomain: !ImportValue EmailDomain } ]
+          FROM_ADDRESS: !Sub [ "${EmailSenderID} <admin-tool@${emailDomain}>", { emailDomain: !ImportValue EmailDomain } ]
       Policies:
         - Version: 2012-10-17
           Statement:
@@ -91,7 +97,7 @@ Resources:
             Resource: !ImportValue EmailIdentityARN
             Condition:
               StringEquals:
-                ses:FromAddress: !Sub [ "admin-tool@${emailDomain}", { emailDomain: !ImportValue EmailDomain } ]
+                ses:FromAddress: !Sub [ "${EmailSenderID} <admin-tool@${emailDomain}>", { emailDomain: !ImportValue EmailDomain } ]
       Events:
         Cognito:
           Type: Cognito
@@ -100,10 +106,10 @@ Resources:
             UserPool: !Ref UserPool
 
   CreatePasswordResetMessageFunction:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: esbuild
@@ -121,10 +127,10 @@ Resources:
             UserPool: !Ref UserPool
 
   SecurityCodeTextMessageSender:
-    # checkov:skip=CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
-    # checkov:skip=CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
-    # checkov:skip=CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
-    # checkov:skip=CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
+    # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+    # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
+    # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+    # checkov:skip=CKV_AWS_173:Check encryption settings for Lambda environmental variable
     Type: AWS::Serverless::Function
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
@@ -185,12 +191,12 @@ Resources:
             MaxLength: 2048
       AutoVerifiedAttributes: [ email ]
       UsernameAttributes: [ email ]
-      EmailVerificationMessage: |-
+      EmailVerificationMessage: !Sub |-
         <html>
           <head>
             <meta name="viewport" content="width=device-width, initial-scale=1.0" />
             <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-            <title>Your security code for the GOV.UK One Login admin tool</title>
+            <title>Your security code for the ${ProductName}</title>
             <style>
               body {
                 -webkit-font-smoothing: antialiased;
@@ -319,14 +325,14 @@ Resources:
             </table>
           </body>
         </html>
-      EmailVerificationSubject: Your security code for the GOV.UK One Login Admin Tool
+      EmailVerificationSubject: !Sub Your security code for the ${ProductName}
       VerificationMessageTemplate:
-        EmailMessage: |-
+        EmailMessage: !Sub |-
           <html>
             <head>
               <meta name="viewport" content="width=device-width, initial-scale=1.0" />
               <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-              <title>Your security code for the GOV.UK One Login Admin Tool</title>
+              <title>Your security code for the ${ProductName}</title>
               <style>
                 body {
                   -webkit-font-smoothing: antialiased;
@@ -406,7 +412,7 @@ Resources:
                             font-size: 24px;
                             line-height: 32px;
                             color: white;
-                            "> One Login Admin Tool <strong style="display: inline-block;
+                            "> One Login admin tool <strong style="display: inline-block;
                                 outline: 2px solid transparent;
                                 outline-offset: -2px;
                                 color: #ffffff;
@@ -455,7 +461,7 @@ Resources:
               </table>
             </body>
           </html>
-        EmailSubject: Your security code for the GOV.UK One Login Admin Tool
+        EmailSubject: !Sub Your security code for the ${ProductName}
         DefaultEmailOption: CONFIRM_WITH_CODE
       MfaConfiguration: OPTIONAL
       EnabledMfas: [ SMS_MFA ]
@@ -466,7 +472,7 @@ Resources:
       EmailConfiguration:
         EmailSendingAccount: DEVELOPER
         SourceArn: !ImportValue EmailIdentityARN
-        From: !Sub [ "admin-tool@${emailDomain}", { emailDomain: !ImportValue EmailDomain } ]
+        From: !Sub [ "${EmailSenderID} <admin-tool@${emailDomain}>", { emailDomain: !ImportValue EmailDomain } ]
       # https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-sms-settings.html
       LambdaConfig:
         CustomSMSSender:
@@ -476,12 +482,12 @@ Resources:
       AdminCreateUserConfig:
         AllowAdminCreateUserOnly: false
         InviteMessageTemplate:
-          EmailMessage: |-
+          EmailMessage: !Sub |-
             <html>
               <head>
                 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
                 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-                <title>Your security code for the GOV.UK One Login Admin Tool</title>
+                <title>Your security code for the ${ProductName}</title>
                 <style>
                   body {
                     -webkit-font-smoothing: antialiased;
@@ -561,7 +567,7 @@ Resources:
                               font-size: 24px;
                               line-height: 32px;
                               color: white;
-                              "> One Login Admin Tool <strong style="display: inline-block;
+                              "> One Login admin tool <strong style="display: inline-block;
                                   outline: 2px solid transparent;
                                   outline-offset: -2px;
                                   color: #ffffff;
@@ -611,7 +617,7 @@ Resources:
                       </table>
               </body>
             </html>
-          EmailSubject: Your security code for the GOV.UK One Login Admin Tool
+          EmailSubject: !Sub Your security code for the ${ProductName}
       UsernameConfiguration:
         CaseSensitive: false
       AccountRecoverySetting:

--- a/backend/dynamodb/dynamodb.template.yml
+++ b/backend/dynamodb/dynamodb.template.yml
@@ -17,8 +17,8 @@ Conditions:
 
 Resources:
   DataTable:
-    # checkov:skip=CKV_AWS_28: "Ensure Dynamodb point in time recovery (backup) is enabled"
-    # checkov:skip=CKV_AWS_119: "Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK"
+    # checkov:skip=CKV_AWS_28:Ensure Dynamodb point in time recovery (backup) is enabled
+    # checkov:skip=CKV_AWS_119:Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK
     Type: AWS::DynamoDB::Table
     Properties:
       TableClass: STANDARD
@@ -49,8 +49,8 @@ Resources:
 
   SessionsTable:
     # https://github.com/ca98am79/connect-dynamodb#options
-    # checkov:skip=CKV_AWS_28: "Ensure Dynamodb point in time recovery (backup) is enabled"
-    # checkov:skip=CKV_AWS_119: "Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK"
+    # checkov:skip=CKV_AWS_28:Ensure Dynamodb point in time recovery (backup) is enabled
+    # checkov:skip=CKV_AWS_119:Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK
     Type: AWS::DynamoDB::Table
     Properties:
       TableClass: STANDARD

--- a/infrastructure/dev/deploy.sh
+++ b/infrastructure/dev/deploy.sh
@@ -96,7 +96,7 @@ function cognito {
 }
 
 function api {
-  deploy-backend-component api --build --base-dir "$REPO_ROOT" --params LogGroupNamePrefix=$LOG_PREFIX
+  deploy-backend-component api --build --base-dir "$REPO_ROOT" --params LogGroupPrefix=$LOG_PREFIX PrivateAPI=false
 }
 
 function all {

--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -3,108 +3,120 @@ Description: DI Admin Tool frontend
 Transform: AWS::LanguageExtensions
 
 Parameters:
+  ImageURI:
+    Type: String
+    Default: ""
+    Description: The URI of the ECR image to use for the container
+  ContainerPort:
+    Type: Number
+    Default: 3000
+  LogGroupPrefix:
+    Type: String
+    AllowedPattern: ^.*[^\/]$
+    Default: /aws/vendedlogs
   DeploymentName:
     Type: String
     MaxLength: 28
     AllowedPattern: ^.*[^-]$
     Default: self-service
     Description: A unique prefix to identify the deployment; used when importing or exporting values from related stacks
-  VpcStackName:
-    Type: String
-    Description: The name of the stack that defines the VPC in which the frontend container will run
+  ShowTestBanner:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /self-service/frontend/show-test-banner
+  GoogleTagID:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /self-service/frontend/google-tag-id
   PermissionsBoundary:
     Type: String
     Default: ""
     Description: The ARN of the permissions boundary to apply when creating IAM roles
 
 Mappings:
-  # See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
-  ElasticLoadBalancerAccountIds:
+  # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
+  ElasticLoadBalancer:
     eu-west-2:
-      AccountId: 652711504416
+      AccountID: 652711504416
 
 Conditions:
   UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundary, "" ] ]
 
 Resources:
-  ECSCluster:
-    Type: AWS::ECS::Cluster
-    Properties:
-      CapacityProviders: [ FARGATE, FARGATE_SPOT ]
-      ClusterSettings:
-        - Name: containerInsights
-          Value: enabled
-      Configuration:
-        ExecuteCommandConfiguration:
-          Logging: DEFAULT
 
-  ContainerService:
-    Type: AWS::ECS::Service
-    DependsOn: ApplicationLoadBalancerListener
-    Properties:
-      Cluster: !Ref ECSCluster
-      LaunchType: FARGATE
-      SchedulingStrategy: REPLICA
-      DeploymentController:
-        Type: ECS
-      LoadBalancers:
-        - ContainerName: frontend
-          ContainerPort: 3000
-          TargetGroupArn: !Ref ApplicationLoadBalancerTargetGroup
-      NetworkConfiguration:
-        AwsvpcConfiguration:
-          AssignPublicIp: ENABLED
-          SecurityGroups: [ !GetAtt ContainerServiceSecurityGroup.GroupId ]
-          Subnets:
-            - Fn::ImportValue:
-                !Sub ${VpcStackName}-PrivateSubnetIdA
-            - Fn::ImportValue:
-                !Sub ${VpcStackName}-PrivateSubnetIdB
-      PropagateTags: SERVICE
-      TaskDefinition: !Ref TaskDefinition
+  #--- Fargate / ECS ---#
 
-  ContainerServiceSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
     Properties:
-      GroupDescription: Security group to access the container service
-      SecurityGroupIngress:
-        - Description: Allow traffic from the load balancer
-          SourceSecurityGroupId: !GetAtt ApplicationLoadBalancerSecurityGroup.GroupId
-          IpProtocol: tcp
-          FromPort: 80 # ALB port
-          ToPort: 3000 # Container port
-      VpcId:
-        Fn::ImportValue:
-          !Sub ${VpcStackName}-VpcId
+      RequiresCompatibilities: [ FARGATE ]
+      TaskRoleArn: !GetAtt TaskRole.Arn
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      Cpu: 256
+      Memory: 512
+      Family: !Sub ${DeploymentName}
+      NetworkMode: awsvpc
+      ContainerDefinitions:
+        - Name: self-service-frontend
+          Image: !Ref ImageURI
+          Environment:
+            - Name: PORT
+              Value: !Ref ContainerPort
+            - Name: TEST_BANNER
+              Value: !Ref ShowTestBanner
+            - Name: GOOGLE_TAG_ID
+              Value: !Ref GoogleTagID
+            - Name: SESSIONS_TABLE
+              Value:
+                Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-SessionsTableName
+            - Name: API_BASE_URL
+              Value:
+                Fn::ImportValue: !Sub ${DeploymentName}-API-BaseURL
+            - Name: COGNITO_USER_POOL_ID
+              Value:
+                Fn::ImportValue: !Sub ${DeploymentName}-Cognito-UserPoolID
+            - Name: COGNITO_CLIENT_ID
+              Value:
+                Fn::ImportValue: !Sub ${DeploymentName}-Cognito-UserPoolClientID
+          PortMappings:
+            - ContainerPort: !Ref ContainerPort
+          HealthCheck:
+            Command: [ "CMD", "wget", "--spider", !Sub "http://localhost:${ContainerPort}" ]
+          LogConfiguration:
+            # https://docs.docker.com/config/containers/logging/awslogs/
+            LogDriver: awslogs
+            Options:
+              # Consider lines not starting with whitespace as a multi-line log message boundary
+              awslogs-multiline-pattern: ^[^\s}]+.*$
+              awslogs-group: !Sub ${LogGroupPrefix}/${DeploymentName}/frontend
+              awslogs-stream-prefix: ecs
+              awslogs-create-group: true
+              awslogs-region: !Ref AWS::Region
 
-  ECSExecutionRole:
+  ExecutionRole:
     Type: AWS::IAM::Role
     Properties:
+      Description: Grant the Fargate and ECS container agents permissions to make AWS API calls and access ECR
       PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
+      ManagedPolicyArns: [ arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy ]
       AssumeRolePolicyDocument:
+        Version: 2012-10-17
         Statement:
           - Effect: Allow
             Action: sts:AssumeRole
             Principal:
-              Service: [ ecs-tasks.amazonaws.com ]
-      ManagedPolicyArns: [ arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy ]
+              Service: ecs-tasks.amazonaws.com
+      Policies:
+        - PolicyName: CreateLogGroup
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: logs:CreateLogGroup
+                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${LogGroupPrefix}/${DeploymentName}/frontend*
 
-  TaskExecutionPolicy:
-    # checkov:skip=CKV_AWS_111:Ensure IAM policies does not allow write access without constraints
-    Type: AWS::IAM::Policy
-    Properties:
-      Roles: [ !Ref ECSExecutionRole ]
-      PolicyName: TaskExecutionPolicy
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action: logs:CreateLogGroup
-            Resource: "*"
-
-  ECSTaskRole:
+  TaskRole:
     Type: AWS::IAM::Role
     Properties:
+      Description: Allow the Frontend application tasks to access AWS services
       PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
       AssumeRolePolicyDocument:
         Statement:
@@ -117,67 +129,163 @@ Resources:
                 aws:SourceArn: !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:*
       Policies:
         # https://github.com/ca98am79/connect-dynamodb#iam-permissions
-        - PolicyName: SessionStorageTableAccess
+        - PolicyName: SessionStorageTable
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Action:
-                  - dynamodb:DescribeTable
+                  - dynamodb:Scan
                   - dynamodb:GetItem
                   - dynamodb:PutItem
                   - dynamodb:UpdateItem
                   - dynamodb:DeleteItem
-                  - dynamodb:Scan
+                  - dynamodb:DescribeTable
                 Resource:
                   Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-SessionsTableARN
+        - PolicyName: Cognito
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - cognito-idp:AdminCreateUser
+                  - cognito-idp:AdminInitiateAuth
+                  - cognito-idp:AdminUpdateUserAttributes
+                  - cognito-idp:AdminSetUserMFAPreference
+                  - cognito-idp:AdminRespondToAuthChallenge
+                Resource:
+                  Fn::ImportValue: !Sub ${DeploymentName}-Cognito-UserPoolARN
 
-  TaskDefinition:
-    Type: AWS::ECS::TaskDefinition
+  FargateCluster:
+    Type: AWS::ECS::Cluster
     Properties:
-      RequiresCompatibilities: [ FARGATE ]
-      ExecutionRoleArn: !GetAtt ECSExecutionRole.Arn
-      TaskRoleArn: !GetAtt ECSTaskRole.Arn
-      Cpu: 256
-      Memory: 512
-      Family: !Ref DeploymentName
-      NetworkMode: awsvpc
-      ContainerDefinitions:
-        - Name: frontend
-          Image: CONTAINER-IMAGE-PLACEHOLDER
-          MemoryReservation: 256
-          Memory: 512
-          PortMappings:
-            - ContainerPort: 3000
-              Protocol: tcp
-          Essential: true
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              awslogs-group: /self-service
-              awslogs-stream-prefix: frontend
-              awslogs-region: !Ref AWS::Region
-              awslogs-create-group: true
-          Environment:
-            - Name: SESSION_SECRET
-              Value: "{{resolve:secretsmanager:/self-service/frontend/session-secret:SecretString}}"
+      ClusterName: !Ref DeploymentName
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
+
+  ContainerService:
+    Type: AWS::ECS::Service
+    DependsOn: ApplicationLoadBalancerListener
+    Properties:
+      ServiceName: self-service-frontend
+      Cluster: !GetAtt FargateCluster.Arn
+      TaskDefinition: !Ref TaskDefinition
+      PropagateTags: SERVICE
+      LaunchType: FARGATE
+      DesiredCount: 1
+      LoadBalancers:
+        - ContainerName: self-service-frontend
+          ContainerPort: !Ref ContainerPort
+          TargetGroupArn: !Ref ApplicationTargetGroup
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          SecurityGroups:
+            - !GetAtt ContainerServiceSecurityGroup.GroupId
+          Subnets: !Split
+            - ","
+            - Fn::ImportValue: VPC-ProtectedSubnets
+
+  ContainerServiceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Frontend container service access
+      SecurityGroupIngress:
+        - Description: Allow traffic from the application load balancer
+          SourceSecurityGroupId: !GetAtt ApplicationSecurityGroup.GroupId
+          IpProtocol: tcp
+          FromPort: !Ref ContainerPort
+          ToPort: !Ref ContainerPort
+      VpcId:
+        Fn::ImportValue: VPC-ID
+      Tags:
+        - Key: Name
+          Value: !Sub ${DeploymentName}-frontend-container-service
+
+  #--- Application load balancing ---#
+
+  ApplicationLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Type: application
+      Scheme: internal
+      Name: !Sub ${DeploymentName}-frontend
+      SecurityGroups:
+        - !Ref ApplicationSecurityGroup
+      Subnets: !Split
+        - ","
+        - Fn::ImportValue: VPC-ProtectedSubnets
+      LoadBalancerAttributes:
+        - Key: routing.http.drop_invalid_header_fields.enabled
+          Value: true
+        - Key: access_logs.s3.enabled
+          Value: true
+        - Key: access_logs.s3.bucket
+          Value: !Ref AccessLogsBucket
+
+  ApplicationTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub ${DeploymentName}-app
+      Port: !Ref ContainerPort
+      Protocol: HTTP
+      TargetType: ip
+      VpcId:
+        Fn::ImportValue: VPC-ID
+
+  ApplicationLoadBalancerListener:
+    # checkov:skip=CKV_AWS_2:Certificate generation must be resolved before the listener can use HTTPS
+    # checkov:skip=CKV_AWS_103:The load balancer cannot use TLS v1.2 until HTTPS is enabled
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      Port: 80
+      Protocol: HTTP
+      LoadBalancerArn: !Ref ApplicationLoadBalancer
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref ApplicationTargetGroup
+
+  ApplicationSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Frontend application load balancer
+      SecurityGroupIngress:
+        - Description: Allow traffic from the VPC
+          IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp:
+            Fn::ImportValue: VPC-CIDR
+      VpcId:
+        Fn::ImportValue: VPC-ID
+      Tags:
+        - Key: Name
+          Value: !Sub ${DeploymentName}-frontend-application-load-balancer
+
+  ApplicationSecurityGroupEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !GetAtt ApplicationSecurityGroup.GroupId
+      Description: Allow traffic to the frontend container service
+      DestinationSecurityGroupId: !GetAtt ContainerServiceSecurityGroup.GroupId
+      IpProtocol: tcp
+      FromPort: !Ref ContainerPort
+      ToPort: !Ref ContainerPort
 
   AccessLogsBucket:
     # checkov:skip=CKV_AWS_18:Ensure the S3 bucket has access logging enabled
+    # checkov:skip=CKV_AWS_21:Ensure the S3 bucket has versioning enabled
     Type: AWS::S3::Bucket
     Properties:
-      VersioningConfiguration:
-        Status: Enabled
+      BucketName: !Sub ${DeploymentName}-frontend-alb-logs
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
 
+  # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   AccessLogsBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
@@ -186,174 +294,91 @@ Resources:
         Version: 2012-10-17
         Statement:
           - Effect: Allow
-            Principal:
-              AWS: !Sub
-                - arn:aws:iam::${ElbAccountId}:root
-                - ElbAccountId: !FindInMap [ ElasticLoadBalancerAccountIds, !Ref AWS::Region, AccountId ]
             Action: s3:PutObject
-            Resource: !Sub arn:aws:s3:::${AccessLogsBucket}/sse-front-alb/AWSLogs/${AWS::AccountId}/*
+            Resource: !Sub ${AccessLogsBucket.Arn}/AWSLogs/${AWS::AccountId}/*
+            Principal:
+              AWS: !FindInMap [ ElasticLoadBalancer, !Ref AWS::Region, AccountID ]
 
-  ApplicationLoadBalancer:
-    # checkov:skip=CKV_AWS_91:Ensure the ELBv2 (Application/Network) has access logging enabled
-    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
-    Properties:
-      Scheme: internal
-      SecurityGroups: [ !GetAtt ApplicationLoadBalancerSecurityGroup.GroupId ]
-      Subnets:
-        - Fn::ImportValue:
-            !Sub ${VpcStackName}-PrivateSubnetIdA
-        - Fn::ImportValue:
-            !Sub ${VpcStackName}-PrivateSubnetIdB
-      LoadBalancerAttributes:
-        - Key: access_logs.s3.enabled
-          Value: true
-        - Key: access_logs.s3.bucket
-          Value: !Ref AccessLogsBucket
-        - Key: access_logs.s3.prefix
-          Value: sse-front-alb
-        - Key: routing.http.drop_invalid_header_fields.enabled
-          Value: true
+  #--- Network load balancing ---#
 
-  ApplicationLoadBalancerTargetGroup:
+  NetworkLoadBalancerTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      HealthCheckPort: 3000
-      HealthCheckProtocol: HTTP
-      HealthCheckPath: /
+      Name: !Sub ${DeploymentName}-net
       Port: 80
-      Protocol: HTTP
-      ProtocolVersion: HTTP1
-      Matcher:
-        HttpCode: "200-499" # might be 200
-      TargetType: ip
+      Protocol: TCP
+      TargetType: alb
+      Targets:
+        - Id: !Ref ApplicationLoadBalancer
       VpcId:
-        Fn::ImportValue:
-          !Sub ${VpcStackName}-VpcId
-
-  ApplicationLoadBalancerListener:
-    # checkov:skip=CKV_AWS_2:Certificate generation must be resolved before the listener can use HTTPS.
-    # checkov:skip=CKV_AWS_103:The load balancer cannot use TLS v1.2 until HTTPS is enabled.
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    Properties:
-      DefaultActions:
-        - TargetGroupArn: !Ref ApplicationLoadBalancerTargetGroup
-          Type: forward
-      LoadBalancerArn: !Ref ApplicationLoadBalancer
-      Port: 80
-      Protocol: HTTP
-
-  ApplicationLoadBalancerSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Security Group for the application load balancer
-      GroupName: !Sub ${AWS::StackName}-ApplicationLoadBalancer
-      VpcId:
-        Fn::ImportValue:
-          !Sub ${VpcStackName}-VpcId
-
-  ApplicationLoadBalancerSecurityGroupIngress:
-    # checkov:skip=CKV_AWS_260:Ensure no security groups allow ingress from 0.0.0.0:0 to port 80
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      GroupId: !GetAtt ApplicationLoadBalancerSecurityGroup.GroupId
-      CidrIp: "0.0.0.0/0"
-      # CidrIp:
-      #   Fn::ImportValue:
-      #     !Sub "${VpcStackName}-VpcCidr"
-      Description: Allow traffic from the VPC / outside
-      IpProtocol: tcp
-      FromPort: 80
-      ToPort: 80
-
-  ApplicationLoadBalancerSecurityGroupEgress:
-    Type: AWS::EC2::SecurityGroupEgress
-    Properties:
-      GroupId: !GetAtt ApplicationLoadBalancerSecurityGroup.GroupId
-      DestinationSecurityGroupId: !GetAtt ContainerServiceSecurityGroup.GroupId
-      Description: Allow traffic to the container service
-      IpProtocol: -1
-      FromPort: 0
-      ToPort: 65535
-
-  APIGatewayEndpoint:
-    Type: AWS::ApiGatewayV2::Api
-    Properties:
-      Name: !Sub ${AWS::StackName}
-      ProtocolType: HTTP
-
-  APIGatewayEndpointIntegration:
-    Type: AWS::ApiGatewayV2::Integration
-    Properties:
-      ApiId: !Ref APIGatewayEndpoint
-      IntegrationType: HTTP_PROXY
-      ConnectionId:
-        Fn::ImportValue:
-          !Sub ${VpcStackName}-VpcLinkId
-      ConnectionType: VPC_LINK
-      IntegrationMethod: ANY
-      IntegrationUri: !Ref NetworkLoadBalancerListener
-      PayloadFormatVersion: 1.0
-
-  APIGatewayRoute:
-    Type: AWS::ApiGatewayV2::Route
-    Properties:
-      ApiId: !Ref APIGatewayEndpoint
-      RouteKey: ANY /{proxy+}
-      Target: !Sub integrations/${APIGatewayEndpointIntegration}
-
-  APIStage:
-    Type: AWS::ApiGatewayV2::Stage
-    Properties:
-      ApiId: !Ref APIGatewayEndpoint
-      StageName: $default
-      AutoDeploy: true
-      AccessLogSettings:
-        DestinationArn: !GetAtt APIGWAccessLogsGroup.Arn
-        Format:
-          Fn::ToJsonString:
-            requestId: $context.requestId
-            ip: $context.identity.sourceIp
-            requestTime: $context.requestTime
-            httpMethod: $context.httpMethod
-            path: $context.path"
-            routeKey: $context.routeKey
-            status: $context.status
-            protocol: $context.protocol
-            responseLength: $context.responseLength
-
-  APIGWAccessLogsGroup:
-    # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-sseFront-API-GW-AccessLogs
-      RetentionInDays: 14
+        Fn::ImportValue: VPC-ID
 
   NetworkLoadBalancerListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
+      Port: 80
+      Protocol: TCP
+      LoadBalancerArn:
+        Fn::ImportValue: VPC-NetworkLoadBalancerARN
       DefaultActions:
         - Type: forward
           TargetGroupArn: !Ref NetworkLoadBalancerTargetGroup
-      LoadBalancerArn:
-        Fn::ImportValue:
-          !Sub ${VpcStackName}-ApiGatewayVpcLinkTargetNLB
-      Port: 80
-      Protocol: TCP
 
-  NetworkLoadBalancerTargetGroup:
-    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    DependsOn: ApplicationLoadBalancerListener
+  #--- Public access / API Gateway ---#
+
+  PublicAPI:
+    Type: AWS::ApiGatewayV2::Api
     Properties:
-      Name: !Sub ${AWS::StackName}-NLBTarGrp
-      Port: 80
-      Protocol: TCP
-      Targets:
-        - Id: !Ref ApplicationLoadBalancer
-      TargetType: alb
-      VpcId:
-        Fn::ImportValue:
-          !Sub ${VpcStackName}-VpcId
+      Name: !Sub ${DeploymentName}-frontend
+      ProtocolType: HTTP
 
-Outputs:
-  AdminToolURL:
-    Value: !GetAtt APIGatewayEndpoint.ApiEndpoint
+  APIProxy:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref PublicAPI
+      RouteKey: ANY /{proxy+}
+      Target: !Sub integrations/${VPCLinkIntegration}
+
+  APIStage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      ApiId: !Ref PublicAPI
+      StageName: $default
+      AutoDeploy: true
+      DefaultRouteSettings:
+        DetailedMetricsEnabled: true
+      AccessLogSettings:
+        DestinationArn: !GetAtt APIAccessLogsGroup.Arn
+        Format:
+          Fn::ToJsonString:
+            path: $context.path
+            status: $context.status
+            protocol: $context.protocol
+            routeKey: $context.routeKey
+            requestId: $context.requestId
+            requestTime: $context.requestTime
+            httpMethod: $context.httpMethod
+            responseLength: $context.responseLength
+            extendedRequestId: $context.extendedRequestId
+            integrationStatus: $context.integration.status
+            integrationError: $context.integration.error
+            customDomainPath: $context.customDomain.basePathMatched
+
+  APIAccessLogsGroup:
+    # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/frontend/api-gateway
+      RetentionInDays: 14
+
+  VPCLinkIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref PublicAPI
+      PayloadFormatVersion: 1.0
+      IntegrationMethod: ANY
+      IntegrationType: HTTP_PROXY
+      IntegrationUri: !Ref NetworkLoadBalancerListener
+      ConnectionType: VPC_LINK
+      ConnectionId:
+        Fn::ImportValue: VPC-LinkID


### PR DESCRIPTION
**Make the backend API private by default**

When the frontend runs in the VPC, it can only communicate with the backend API Gateway via a VPC endpoint, meaning the endpoint must be set to private and the VPC subnets needs to be provided.

When running the frontend locally, we need the API to be public, so add a param to enable that and not set the private endpoint config.

Note that the API URL is different when executed through a VPC endpoint, hence the conditional on the output value.

Use a REST API as it's the only one that supports private endpoints.

**Update the frontend template**

- Set up ECS service
- Add container logs
- Add ECS params & env vars
- Add Cognito permissions
- Set up container healtcheck
- Don't assign public IP to frontend service as we'll be using API Gateway and CloudFront to get public access
- Import subnet list from the VPC stack
- Update task role permissions

- Use HTTP API for frontend API Gateway

- Add API Gateway access log settings

- Configure multiline logging for the awslogs driver

---

**Set the session secret automatically**

If the secret is not present, generate a new UUID value.