### PR TITLE
Add custom Cognito attribute for tracking the signup status.

### DIFF
--- a/backend/cognito/cognito.template.yml
+++ b/backend/cognito/cognito.template.yml
@@ -189,6 +189,11 @@ Resources:
           StringAttributeConstraints:
             MinLength: 0
             MaxLength: 2048
+        - Name: signup_status
+          AttributeDataType: String
+          DeveloperOnlyAttribute: false
+          Mutable: true
+          Required: false
       AutoVerifiedAttributes: [ email ]
       UsernameAttributes: [ email ]
       EmailVerificationMessage: !Sub |-


### PR DESCRIPTION
Add custom attribute to allow signup to be restarted from the place it last reached. Per Cognito rules, it cannot be set as required or with any default value, so correct population must be enforced in code.