### PR TITLE
SSE-2735: Cognito SMS sender test

### DIFF
--- a/backend/cognito/tests/mocks.ts
+++ b/backend/cognito/tests/mocks.ts
@@ -1,0 +1,4 @@
+import {CustomSMSSenderTriggerEvent} from "aws-lambda";
+
+export const smsSenderTrigger = (number: string, code?: string) =>
+    ({request: {code: code, userAttributes: {phone_number: number}}} as unknown as CustomSMSSenderTriggerEvent);


### PR DESCRIPTION
Apply common patterns and best practices to the SMS sender lambda from other unit tests

- When creating mocks, only hold references to things that need to be used in the tests
- Set up the mock for `smsSenderTrigger` in a separate file for reuse - use a double type assertion to create an "optional" type and avoid having to specify all the properties each time
- Use `expect....rejects` to check that an async function throws an error instead of `try....catch`