### PR TITLE
SSE-2063: Set frontend deployment URL

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -17,11 +17,11 @@ jobs:
     uses: ./.github/workflows/run-unit-tests.yml
 
   deploy-preview-frontend:
-    name: Preview
+    name: PaaS
     needs: build-frontend
     uses: ./.github/workflows/deploy-to-paas.yml
     with:
-      environment: preview
+      environment: PaaS
       app-name-prefix: di-sse-prev
       cf-space-name: self-service-preview
       artifact-name: ${{ needs.build-frontend.outputs.artifact-name }}

--- a/.github/workflows/clean-up-deployments.yml
+++ b/.github/workflows/clean-up-deployments.yml
@@ -13,7 +13,7 @@ jobs:
   delete-paas-deployments:
     name: Clean up PaaS apps
     runs-on: ubuntu-latest
-    environment: preview
+    environment: PaaS
     concurrency: deploy-paas-preview-${{ github.head_ref || github.ref_name }}
     steps:
       - name: PaaS login

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -12,9 +12,9 @@ permissions:
 
 jobs:
   delete-frontend-paas:
-    name: Delete app preview
+    name: Delete frontend PaaS
     runs-on: ubuntu-latest
-    environment: preview
+    environment: PaaS
     concurrency: deploy-paas-preview-${{ github.head_ref || github.ref_name }}
     permissions: { }
     steps:

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -1,7 +1,9 @@
-name: Deploy branch preview
+name: Preview
 run-name: Deploy preview [${{ github.head_ref || github.ref_name }}]
 
-on: workflow_dispatch
+on:
+  pull_request:
+  workflow_dispatch:
 
 permissions:
   id-token: write

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -26,6 +26,7 @@ jobs:
     uses: ./.github/workflows/deploy-component.yml
     with:
       name: Frontend
+      deployment-url-output: AdminToolURL
       template: infrastructure/frontend/frontend.template.yml
       parameters: |
         ImageURI=${{ needs.push-frontend-image.outputs.image-uri }}

--- a/.github/workflows/deploy-component.yml
+++ b/.github/workflows/deploy-component.yml
@@ -7,6 +7,7 @@ on:
       template: { required: false, type: string }
       artifact: { required: false, type: string }
       parameters: { required: false, type: string }
+      deployment-url-output: { required: false, type: string }
       disable-rollback: { required: false, type: boolean, default: false }
     outputs:
       stack-name:
@@ -28,19 +29,19 @@ jobs:
 
     environment:
       name: development
-      url: ${{ steps.deploy.outputs.stack-url }}
+      url: ${{ steps.get-deployment-url.outputs.url || steps.deploy.outputs.stack-url }}
 
     steps:
       - name: Get deployment name
         uses: alphagov/di-github-actions/beautify-branch-name@299bdda5b093a5d13c76e4d0f97f59bc727b4e03
         id: get-deployment-name
         with:
-          usage: Deployment name
           length-limit: 28
           prefix: preview
+          verbose: false
 
       - name: Deploy stack
-        uses: alphagov/di-github-actions/sam/deploy-stack@299bdda5b093a5d13c76e4d0f97f59bc727b4e03
+        uses: alphagov/di-github-actions/sam/deploy-stack@254be85cdee8fb8a57e9cdddf53e74c469925168
         id: deploy
         with:
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
@@ -59,3 +60,14 @@ jobs:
           parameters: |-
             DeploymentName=${{ steps.get-deployment-name.outputs.pretty-branch-name }}
             ${{ inputs.parameters }}
+
+      - name: Get deployment URL
+        id: get-deployment-url
+        if: ${{ inputs.deployment-url-output != null }}
+        env:
+          NAME: ${{ inputs.deployment-url-output }}
+          OUTPUTS: ${{ steps.deploy.outputs.stack-outputs }}
+        run: |
+          url=$(jq --raw-output ".$NAME" <<< "$OUTPUTS")
+          printf "🌐 Deployment URL\n%s" "$url" >> "$GITHUB_STEP_SUMMARY"
+          echo "url=$url" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-to-paas.yml
+++ b/.github/workflows/deploy-to-paas.yml
@@ -1,4 +1,4 @@
-name: Deploy to PaaS
+name: Deploy frontend to PaaS
 
 on:
   workflow_call:
@@ -27,7 +27,7 @@ concurrency: deploy-paas-${{ inputs.environment }}-${{ github.head_ref || github
 
 jobs:
   deploy:
-    name: Deploy to PaaS
+    name: Deploy frontend
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.environment }}

--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -280,4 +280,4 @@ Resources:
 
 Outputs:
   AdminToolURL:
-    Value: !Ref DNSRecord
+    Value: !Sub https://${DNSRecord}


### PR DESCRIPTION
- Deploy branch preview to AWS on pull requests

- Set the deployment URL to the URL of the deployed Admin Tool instance

- Rename "preview" environment to "PaaS" to reflect the fact that previews go to AWS and PaaS is used only for acceptance tests