### PR TITLE
SSE-2649: Add VPC config to Cognito lambdas

### DIFF
--- a/.github/workflows/deploy-component.yml
+++ b/.github/workflows/deploy-component.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Get deployment name
-        uses: alphagov/di-github-actions/beautify-branch-name@299bdda5b093a5d13c76e4d0f97f59bc727b4e03
+        uses: alphagov/di-github-actions/beautify-branch-name@62863904d9aef239c1214f8e2d58577f38c9bb76
         id: get-deployment-name
         with:
           length-limit: 28
@@ -41,7 +41,7 @@ jobs:
           verbose: false
 
       - name: Deploy stack
-        uses: alphagov/di-github-actions/sam/deploy-stack@254be85cdee8fb8a57e9cdddf53e74c469925168
+        uses: alphagov/di-github-actions/sam/deploy-stack@62863904d9aef239c1214f8e2d58577f38c9bb76
         id: deploy
         with:
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}

--- a/backend/cognito/cognito.template.yml
+++ b/backend/cognito/cognito.template.yml
@@ -40,6 +40,9 @@ Globals:
     Timeout: 10
     Runtime: nodejs18.x
     PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
+    VpcConfig:
+      SecurityGroupIds: [ !ImportValue VPC-VPCEndpointsSecurityGroup ]
+      SubnetIds: !Split [ ",", !ImportValue VPC-PrivateSubnets ]
     Environment:
       Variables:
         NODE_OPTIONS: --enable-source-maps
@@ -84,10 +87,8 @@ Resources:
       Handler: src/handlers/send-password-changed-email.handler
       Description: Send an email to confirm the user's password has been changed
       CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
-      Environment:
-        Variables:
-          FROM_ADDRESS: !Sub [ "${EmailSenderID} <${DeploymentName}@${Domain}>", { Domain: !ImportValue DNS-Domain } ]
       Policies:
+        - AWSLambdaVPCAccessExecutionRole
         - Version: 2012-10-17
           Statement:
             Effect: Allow
@@ -98,6 +99,9 @@ Resources:
             Condition:
               StringEquals:
                 ses:FromAddress: !Sub [ "${EmailSenderID} <${DeploymentName}@${Domain}>", { Domain: !ImportValue DNS-Domain } ]
+      Environment:
+        Variables:
+          FROM_ADDRESS: !Sub [ "${EmailSenderID} <${DeploymentName}@${Domain}>", { Domain: !ImportValue DNS-Domain } ]
       Events:
         Cognito:
           Type: Cognito
@@ -119,6 +123,7 @@ Resources:
       Handler: src/handlers/create-password-reset-message.handler
       Description: Create a customised email message to send when resetting the user's password
       CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
+      Policies: [ AWSLambdaVPCAccessExecutionRole ]
       Events:
         Cognito:
           Type: Cognito
@@ -126,7 +131,7 @@ Resources:
             Trigger: CustomMessage
             UserPool: !Ref UserPool
 
-  SecurityCodeTextMessageSender:
+  SendSecurityCodeTextMessageFunction:
     # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit
     # checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC
     # checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
@@ -140,16 +145,20 @@ Resources:
       Handler: src/handlers/send-security-code-text-message.lambdaHandler
       CodeSigningConfigArn: !If [ UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
       MemorySize: 1024
+      VpcConfig:
+        SubnetIds: !Split [ ",", !ImportValue VPC-ProtectedSubnets ]
+      Policies:
+        - AWSLambdaVPCAccessExecutionRole
+        - Version: 2012-10-17
+          Statement:
+            Effect: Allow
+            Action: kms:Decrypt
+            Resource: !GetAtt SecurityCodeEncryptionKey.Arn
       Environment:
         Variables:
           NOTIFY_API_KEY: "{{resolve:secretsmanager:/self-service/cognito/notify-api-key}}"
           SECURITY_CODE_TEXT_MESSAGE_TEMPLATE: !Ref SecurityCodeTextMessageTemplate
           DECRYPTION_KEY_ARN: !GetAtt SecurityCodeEncryptionKey.Arn
-      Policies:
-        Statement:
-          Effect: Allow
-          Action: kms:Decrypt
-          Resource: !GetAtt SecurityCodeEncryptionKey.Arn
 
   UserPool:
     Type: AWS::Cognito::UserPool
@@ -476,7 +485,7 @@ Resources:
       # https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-sms-settings.html
       LambdaConfig:
         CustomSMSSender:
-          LambdaArn: !GetAtt SecurityCodeTextMessageSender.Arn
+          LambdaArn: !GetAtt SendSecurityCodeTextMessageFunction.Arn
           LambdaVersion: V1_0
         KMSKeyID: !GetAtt SecurityCodeEncryptionKey.Arn
       AdminCreateUserConfig:
@@ -660,11 +669,11 @@ Resources:
         - ALLOW_ADMIN_USER_PASSWORD_AUTH
         - ALLOW_REFRESH_TOKEN_AUTH
 
-  CognitoInvokeSecurityCodeTextMessageSenderPermission:
+  SendSecurityCodeTextMessageFunctionPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !Ref SecurityCodeTextMessageSender
+      FunctionName: !Ref SendSecurityCodeTextMessageFunction
       Principal: cognito-idp.amazonaws.com
 
 Outputs:

--- a/infrastructure/ci/development/deployment-config.template.yml
+++ b/infrastructure/ci/development/deployment-config.template.yml
@@ -20,6 +20,8 @@ Parameters:
     Default: /self-service/api/notifications-email
 
 Resources:
+  # Service authorisation reference - Actions, resources, and condition keys for AWS services
+  # https://docs.aws.amazon.com/service-authorization/latest/reference/reference_policies_actions-resources-contextkeys.html
   GitHubActionsRole:
     Type: AWS::IAM::Role
     Properties:
@@ -40,7 +42,10 @@ Resources:
             Statement:
               - Effect: Allow
                 Resource: "*"
-                Action: iam:ListPolicies
+                Action:
+                  - iam:ListPolicies
+                  - ec2:DescribeVpcs
+                  - ec2:DescribeSubnets
 
               - Effect: Allow
                 Resource: !GetAtt GitHubDeploymentArtifactsBucket.Arn
@@ -261,6 +266,7 @@ Resources:
               - lambda:AddPermission
               - lambda:RemovePermission
               - lambda:UpdateFunctionCode
+              - lambda:UpdateFunctionConfiguration
               - lambda:ListTags
             Condition:
               StringEqualsIfExists:
@@ -378,6 +384,7 @@ Resources:
               - lambda:AddPermission
               - lambda:RemovePermission
               - lambda:UpdateFunctionCode
+              - lambda:UpdateFunctionConfiguration
 
           - Effect: Allow
             Resource: !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${ServiceName}/cognito/notify-api-key-*

--- a/infrastructure/config/network.template.yml
+++ b/infrastructure/config/network.template.yml
@@ -103,6 +103,10 @@ Outputs:
     Value: !GetAtt VPC.Outputs.ExecuteApiGatewayVpcEndpointId
     Export:
       Name: !Sub ${ExportPrefix}VPC-ExecuteAPIGatewayEndpointID
+  VPCEndpointsSecurityGroup:
+    Value: !GetAtt VPC.Outputs.AWSServicesEndpointSecurityGroupId
+    Export:
+      Name: !Sub ${ExportPrefix}VPC-VPCEndpointsSecurityGroup
   AccessLogsBucket:
     Value: !Ref AccessLogsBucket
     Export:


### PR DESCRIPTION
- Export VPC endpoints security group from the VPC stack
- Use the VPC endpoints security group so lambdas can access AWS services
- Use private subnets as default for Cognito lambdas
- Use the AWS managed policy to allow VPC lambda access
- Override the subnet for the lambda that needs access to external endpoints
- Add permissions for the GitHub Actions role to configure VPC for lambdas