### PR TITLE
OBS-31 Add the Dynatrace one agent to the frontend containe

### DIFF
--- a/.github/workflows/build-frontend-image.yml
+++ b/.github/workflows/build-frontend-image.yml
@@ -33,8 +33,7 @@ jobs:
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367
-          password: dt0c01.I3T5VY3BDKLDCRY5XTSOLWTS.2US3P3ZRREY2YV4NW2X25DP7PFPGCGWUC4BPI5MPYH3Y4MWD6QIUXBABQFAZXRBF
-          #password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+          password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
       - name: Push Docker image
         uses: alphagov/di-github-actions/aws/ecr/build-docker-image@081ce732d75690781b1eb82d85ee11b45934c51e
         id: push-image

--- a/.github/workflows/build-frontend-image.yml
+++ b/.github/workflows/build-frontend-image.yml
@@ -33,7 +33,8 @@ jobs:
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367
-          password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+          password: dt0c01.I3T5VY3BDKLDCRY5XTSOLWTS.2US3P3ZRREY2YV4NW2X25DP7PFPGCGWUC4BPI5MPYH3Y4MWD6QIUXBABQFAZXRBF
+          #password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
       - name: Push Docker image
         uses: alphagov/di-github-actions/aws/ecr/build-docker-image@081ce732d75690781b1eb82d85ee11b45934c51e
         id: push-image

--- a/.github/workflows/build-frontend-image.yml
+++ b/.github/workflows/build-frontend-image.yml
@@ -28,6 +28,12 @@ jobs:
       url: ${{ steps.push-image.outputs.image-url }}
 
     steps:
+      - name: Login to GDS Dev Dynatrace Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: khw46367.live.dynatrace.com
+          username: khw46367
+          password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
       - name: Push Docker image
         uses: alphagov/di-github-actions/aws/ecr/build-docker-image@081ce732d75690781b1eb82d85ee11b45934c51e
         id: push-image

--- a/.github/workflows/build-frontend-image.yml
+++ b/.github/workflows/build-frontend-image.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
     inputs:
       artifact-name: { required: true, type: string }
+      environment: { required: true, type: string }
+    secrets:
+      dynatrace-pass-token: { required: true }
     outputs:
       image-uri:
         value: ${{ jobs.build.outputs.image-uri }}
@@ -24,7 +27,7 @@ jobs:
       image-uri: ${{ steps.push-image.outputs.image-uri }}
 
     environment:
-      name: development
+      name: ${{ inputs.environment }}
       url: ${{ steps.push-image.outputs.image-url }}
 
     steps:
@@ -33,7 +36,7 @@ jobs:
         with:
           registry: khw46367.live.dynatrace.com
           username: khw46367
-          password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+          password: ${{ secrets.dynatrace-pass-token }}
       - name: Push Docker image
         uses: alphagov/di-github-actions/aws/ecr/build-docker-image@081ce732d75690781b1eb82d85ee11b45934c51e
         id: push-image

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -16,13 +16,16 @@ jobs:
     name: Frontend
     permissions: { }
     uses: ./.github/workflows/build-frontend.yml
-
+  
   push-frontend-image:
     name: Frontend
     needs: build-frontend
     uses: ./.github/workflows/build-frontend-image.yml
     with:
       artifact-name: ${{ needs.build-frontend.outputs.artifact-name }}
+      environment: development
+    secrets:
+      dynatrace-pass-token: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
   deploy-frontend:
     name: Frontend

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ dist
 # SAM
 **/.aws-sam
 **/samconfig.toml
+
+# vscode
+.vscode

--- a/infrastructure/ci/development/deployment-config.template.yml
+++ b/infrastructure/ci/development/deployment-config.template.yml
@@ -85,12 +85,12 @@ Resources:
               
               - Effect: Allow
                 Resource: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-                Actions:
+                Action:
                   - secretsmanager:GetSecretValue
               
               - Effect: Allow
                 Resource: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
-                Actions:
+                Action:
                   - secretsmanager:GetSecretValue
               
               - Effect: Allow

--- a/infrastructure/ci/development/deployment-config.template.yml
+++ b/infrastructure/ci/development/deployment-config.template.yml
@@ -82,6 +82,26 @@ Resources:
                   - ssm:GetParameter
                   - ssm:GetParameters
                   - ssm:GetParametersByPath
+              
+              - Effect: Allow
+                Resource: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+                Actions:
+                  - secretsmanager:GetSecretValue
+              
+              - Effect: Allow
+                Resource: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
+                Actions:
+                  - secretsmanager:GetSecretValue
+              
+              - Effect: Allow
+                Action:
+                  - secretsmanager:ListSecrets
+                Resource: 'arn:aws:secretsmanager:eu-west-2:216552277552:secret:*'
+
+              - Effect: Allow
+                Action:
+                  - kms:Decrypt
+                Resource: 'arn:aws:kms:eu-west-2:216552277552:key/*'    
 
   FrontendDeploymentPolicy:
     # checkov:skip=CKV_AWS_111:Ensure IAM policies does not allow write access without constraints

--- a/infrastructure/ci/secure-pipelines/deployment-pipelines.template.yml
+++ b/infrastructure/ci/secure-pipelines/deployment-pipelines.template.yml
@@ -261,6 +261,22 @@ Resources:
           - Effect: Allow
             Action: ecr:BatchDeleteImage
             Resource: !Sub arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/${FrontendECRRepository.Outputs.ContainerRepositoryName}
+          - Effect: Allow
+            Resource: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+            Actions:
+              - secretsmanager:GetSecretValue  
+          - Effect: Allow
+            Resource: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
+            Actions:
+              - secretsmanager:GetSecretValue
+          - Effect: Allow
+            Action:
+              - secretsmanager:ListSecrets
+            Resource: 'arn:aws:secretsmanager:eu-west-2:216552277552:secret:*'
+          - Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource: 'arn:aws:kms:eu-west-2:216552277552:key/*' 
 
 Outputs:
   # Promotion

--- a/infrastructure/ci/secure-pipelines/deployment-pipelines.template.yml
+++ b/infrastructure/ci/secure-pipelines/deployment-pipelines.template.yml
@@ -263,11 +263,11 @@ Resources:
             Resource: !Sub arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/${FrontendECRRepository.Outputs.ContainerRepositoryName}
           - Effect: Allow
             Resource: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-            Actions:
+            Action:
               - secretsmanager:GetSecretValue  
           - Effect: Allow
             Resource: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
-            Actions:
+            Action:
               - secretsmanager:GetSecretValue
           - Effect: Allow
             Action:

--- a/infrastructure/dev/deploy.sh
+++ b/infrastructure/dev/deploy.sh
@@ -123,7 +123,7 @@ function build-frontend-image {
 
   echo "» Building frontend"
   npm run build-express --include-workspace-root &> /dev/null
-  
+
   # TODO not sure on how DYNATRACE_PAAS_TOKEN will be received as a input?
   # docker login khw46367.live.dynatrace.com -u khw46367 -p $DYNATRACE_PAAS_TOKEN
 

--- a/infrastructure/dev/deploy.sh
+++ b/infrastructure/dev/deploy.sh
@@ -124,8 +124,7 @@ function build-frontend-image {
   echo "» Building frontend"
   npm run build-express --include-workspace-root &> /dev/null
 
-  # You need to provide a DYNATRACE_PAAS_TOKEN environment variable which is your 
-  # dynatrace paas token.
+  # You need to provide a DYNATRACE_PAAS_TOKEN environment variable which is your dynatrace paas token.
   docker login khw46367.live.dynatrace.com -u khw46367 -p "$DYNATRACE_PAAS_TOKEN"
 
   echo "» Building Docker image"

--- a/infrastructure/dev/deploy.sh
+++ b/infrastructure/dev/deploy.sh
@@ -125,7 +125,7 @@ function build-frontend-image {
   npm run build-express --include-workspace-root &> /dev/null
   
   # TODO not sure on how DYNATRACE_PAAS_TOKEN will be received as a input?
-  #docker login khw46367.live.dynatrace.com -u khw46367 -p $DYNATRACE_PAAS_TOKEN
+  # docker login khw46367.live.dynatrace.com -u khw46367 -p $DYNATRACE_PAAS_TOKEN
 
   echo "» Building Docker image"
   docker build --quiet --platform linux/amd64 --tag "$repo:$branch" --tag "$image_uri" \

--- a/infrastructure/dev/deploy.sh
+++ b/infrastructure/dev/deploy.sh
@@ -124,8 +124,9 @@ function build-frontend-image {
   echo "» Building frontend"
   npm run build-express --include-workspace-root &> /dev/null
 
-  # TODO not sure on how DYNATRACE_PAAS_TOKEN will be received as a input?
-  # docker login khw46367.live.dynatrace.com -u khw46367 -p $DYNATRACE_PAAS_TOKEN
+  # You need to provide a DYNATRACE_PAAS_TOKEN environment variable with your 
+  # dynatrace paas token.
+  docker login khw46367.live.dynatrace.com -u khw46367 -p $DYNATRACE_PAAS_TOKEN
 
   echo "» Building Docker image"
   docker build --quiet --platform linux/amd64 --tag "$repo:$branch" --tag "$image_uri" \

--- a/infrastructure/dev/deploy.sh
+++ b/infrastructure/dev/deploy.sh
@@ -123,6 +123,9 @@ function build-frontend-image {
 
   echo "» Building frontend"
   npm run build-express --include-workspace-root &> /dev/null
+  
+  # TODO not sure on how DYNATRACE_PAAS_TOKEN will be received as a input?
+  #docker login khw46367.live.dynatrace.com -u khw46367 -p $DYNATRACE_PAAS_TOKEN
 
   echo "» Building Docker image"
   docker build --quiet --platform linux/amd64 --tag "$repo:$branch" --tag "$image_uri" \

--- a/infrastructure/dev/deploy.sh
+++ b/infrastructure/dev/deploy.sh
@@ -126,7 +126,7 @@ function build-frontend-image {
 
   # You need to provide a DYNATRACE_PAAS_TOKEN environment variable which is your 
   # dynatrace paas token.
-  docker login khw46367.live.dynatrace.com -u khw46367 -p $DYNATRACE_PAAS_TOKEN
+  docker login khw46367.live.dynatrace.com -u khw46367 -p "$DYNATRACE_PAAS_TOKEN"
 
   echo "» Building Docker image"
   docker build --quiet --platform linux/amd64 --tag "$repo:$branch" --tag "$image_uri" \

--- a/infrastructure/dev/deploy.sh
+++ b/infrastructure/dev/deploy.sh
@@ -124,7 +124,7 @@ function build-frontend-image {
   echo "» Building frontend"
   npm run build-express --include-workspace-root &> /dev/null
 
-  # You need to provide a DYNATRACE_PAAS_TOKEN environment variable with your 
+  # You need to provide a DYNATRACE_PAAS_TOKEN environment variable which is your 
   # dynatrace paas token.
   docker login khw46367.live.dynatrace.com -u khw46367 -p $DYNATRACE_PAAS_TOKEN
 

--- a/infrastructure/frontend/Dockerfile
+++ b/infrastructure/frontend/Dockerfile
@@ -16,6 +16,8 @@ COPY express/stubs stubs
 COPY express/resources resources
 COPY express/src/views src/views
 COPY express/assets/images assets/images
+COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
 USER node
 CMD STUB_API=${STUB_API:-false} npm start

--- a/infrastructure/frontend/Dockerfile
+++ b/infrastructure/frontend/Dockerfile
@@ -16,7 +16,7 @@ COPY express/stubs stubs
 COPY express/resources resources
 COPY express/src/views src/views
 COPY express/assets/images assets/images
-COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs / /
 ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
 USER node

--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -112,17 +112,20 @@ Resources:
               awslogs-region: !Ref AWS::Region
           Secrets:
             - Name: DT_TENANT
-              ValueFrom: !Sub
-                - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}'
-                - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+              ValueFrom: !Join
+                - ''
+                - - !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+                  - ':DT_TENANT::'
             - Name: DT_TENANTTOKEN
-              ValueFrom: !Sub
-                - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANTTOKEN}}'
-                - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+              ValueFrom: !Join
+                - ''
+                - - !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+                  - ':DT_TENANTTOKEN::'
             - Name: DT_CONNECTION_POINT
-              ValueFrom: !Sub
-                - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_POINT}}'
-                - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+              ValueFrom: !Join
+              - ''
+              - - !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+                - ':DT_CONNECTION_POINT::'
 
   ExecutionRole:
     Type: AWS::IAM::Role

--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -96,6 +96,8 @@ Resources:
             - Name: COGNITO_CLIENT_ID
               Value:
                 Fn::ImportValue: !Sub ${DeploymentName}-Cognito-UserPoolClientID
+            - Name: DT_LOGLEVELCON
+              Value: INFO
           PortMappings:
             - ContainerPort: !Ref ContainerPort
           HealthCheck:

--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -148,6 +148,21 @@ Resources:
               - Effect: Allow
                 Action: logs:CreateLogGroup
                 Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${LogGroupPrefix}/${DeploymentName}/frontend*
+        - PolicyName: GetDynatraceSecret
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource: arn:aws:secretsmanager:eu-west-2:216552277552:secret:*
+              - Effect: Allow
+                Action: secretsmanager:ListSecrets
+                Resource: arn:aws:secretsmanager:eu-west-2:216552277552:secret:*
+              - Effect: Allow
+                Action: kms:Decrypt
+                Resource: arn:aws:kms:eu-west-2:216552277552:key/*
+
+            
 
   TaskRole:
     Type: AWS::IAM::Role

--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -30,10 +30,33 @@ Parameters:
     Type: String
     Default: ""
     Description: The ARN of the permissions boundary to apply when creating IAM roles
+  Environment:
+    Description: "The name of the environment to deploy to."
+    Type: "String"
+    Default: dev
+    AllowedValues:
+    - "dev"
+    - "build"
+    - "staging"
+    - "integration"
+    - "production"
 
 Conditions:
   Subdomain: !Not [ !Equals [ !Ref DeploymentName, self-service ] ]
   UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundary, "" ] ]
+
+Mappings:
+  EnvironmentConfiguration:
+    dev:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+    build:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+    staging:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+    integration:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+    production:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
 
 Resources:
 
@@ -87,6 +110,19 @@ Resources:
               awslogs-stream-prefix: ecs
               awslogs-create-group: true
               awslogs-region: !Ref AWS::Region
+          Secrets:
+            - Name: DT_TENANT
+              ValueFrom: !Sub
+                - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}'
+                - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+            - Name: DT_TENANTTOKEN
+              ValueFrom: !Sub
+                - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANTTOKEN}}'
+                - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+            - Name: DT_CONNECTION_POINT
+              ValueFrom: !Sub
+                - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_POINT}}'
+                - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
 
   ExecutionRole:
     Type: AWS::IAM::Role

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,11 +23,11 @@
         "@typescript-eslint/eslint-plugin": "^5.57.1",
         "@typescript-eslint/parser": "^5.57.1",
         "esbuild": "^0.18.4",
-        "eslint": "^8.49.0",
+        "eslint": "^8.43.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
         "jest": "^29.5.0",
-        "prettier": "^2.8.8",
+        "prettier": "2.8.8",
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.3"
@@ -78,15 +78,6 @@
         "nodemon": "^3.0.1",
         "sass": "^1.60.0",
         "uglify-js": "^3.17.4"
-      }
-    },
-    "node_modules/@aashutoshrathi/word-wrap": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2278,23 +2269,23 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.1.tgz",
-      "integrity": "sha512-PWiOzLIUAjN/w5K17PoF4n6sKBw0gqLHPhywmYHP4t1VFQQVYeb1yWsJwnMVEMl3tUHME7X/SJPZLmtG7XBDxQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
+      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
+      "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.6.0",
+        "espree": "^9.5.2",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -2310,18 +2301,18 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.49.0.tgz",
-      "integrity": "sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.43.0.tgz",
+      "integrity": "sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
-      "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -5204,27 +5195,27 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.49.0.tgz",
-      "integrity": "sha512-jw03ENfm6VJI0jA9U+8H5zfl5b+FvuU3YYvZRdZHOlU2ggJkxrlkJH4HcDrZpj6YwD8kuYqvQM8LyesoazrSOQ==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.43.0.tgz",
+      "integrity": "sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.49.0",
-        "@humanwhocodes/config-array": "^0.11.11",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.0.3",
+        "@eslint/js": "8.43.0",
+        "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.12.4",
+        "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.3",
-        "espree": "^9.6.1",
+        "eslint-scope": "^7.2.0",
+        "eslint-visitor-keys": "^3.4.1",
+        "espree": "^9.5.2",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -5234,6 +5225,7 @@
         "globals": "^13.19.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
@@ -5243,8 +5235,9 @@
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
+        "optionator": "^0.9.1",
         "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
       },
       "bin": {
@@ -5304,9 +5297,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5316,9 +5309,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
+      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -5341,12 +5334,12 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
+      "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.9.0",
+        "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.4.1"
       },
@@ -6121,9 +6114,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.22.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.22.0.tgz",
-      "integrity": "sha512-H1Ddc/PbZHTDVJSnj8kWptIRSD6AM3pK+mKytuIVF4uoBV7rshFlhhvA58ceJ5wp3Er58w6zj7bykMpYXt3ETw==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -8005,17 +7998,17 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
       "dev": true,
       "dependencies": {
-        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0"
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -9811,6 +9804,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,11 +23,11 @@
         "@typescript-eslint/eslint-plugin": "^5.57.1",
         "@typescript-eslint/parser": "^5.57.1",
         "esbuild": "^0.18.4",
-        "eslint": "^8.43.0",
+        "eslint": "^8.49.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
         "jest": "^29.5.0",
-        "prettier": "2.8.8",
+        "prettier": "^2.8.8",
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.3"
@@ -78,6 +78,15 @@
         "nodemon": "^3.0.1",
         "sass": "^1.60.0",
         "uglify-js": "^3.17.4"
+      }
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2269,23 +2278,23 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.1.tgz",
+      "integrity": "sha512-PWiOzLIUAjN/w5K17PoF4n6sKBw0gqLHPhywmYHP4t1VFQQVYeb1yWsJwnMVEMl3tUHME7X/SJPZLmtG7XBDxQ==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
-      "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.5.2",
+        "espree": "^9.6.0",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -2301,18 +2310,18 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.43.0.tgz",
-      "integrity": "sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.49.0.tgz",
+      "integrity": "sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
+      "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -5195,27 +5204,27 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.43.0.tgz",
-      "integrity": "sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.49.0.tgz",
+      "integrity": "sha512-jw03ENfm6VJI0jA9U+8H5zfl5b+FvuU3YYvZRdZHOlU2ggJkxrlkJH4HcDrZpj6YwD8kuYqvQM8LyesoazrSOQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.0.3",
-        "@eslint/js": "8.43.0",
-        "@humanwhocodes/config-array": "^0.11.10",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "8.49.0",
+        "@humanwhocodes/config-array": "^0.11.11",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.5.2",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -5225,7 +5234,6 @@
         "globals": "^13.19.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
@@ -5235,9 +5243,8 @@
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
+        "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
       },
       "bin": {
@@ -5297,9 +5304,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5309,9 +5316,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -5334,12 +5341,12 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
-      "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.8.0",
+        "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.4.1"
       },
@@ -6114,9 +6121,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.22.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.22.0.tgz",
+      "integrity": "sha512-H1Ddc/PbZHTDVJSnj8kWptIRSD6AM3pK+mKytuIVF4uoBV7rshFlhhvA58ceJ5wp3Er58w6zj7bykMpYXt3ETw==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -7998,17 +8005,17 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
       "dev": true,
       "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -9804,15 +9811,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "@typescript-eslint/eslint-plugin": "^5.57.1",
     "@typescript-eslint/parser": "^5.57.1",
     "esbuild": "^0.18.4",
-    "eslint": "^8.43.0",
+    "eslint": "^8.49.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.5.0",
-    "prettier": "2.8.8",
+    "prettier": "^2.8.8",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.3"

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "@typescript-eslint/eslint-plugin": "^5.57.1",
     "@typescript-eslint/parser": "^5.57.1",
     "esbuild": "^0.18.4",
-    "eslint": "^8.49.0",
+    "eslint": "^8.43.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.5.0",
-    "prettier": "^2.8.8",
+    "prettier": "2.8.8",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.3"


### PR DESCRIPTION
- Github workflows
    - In order to log into the dynatrace repo a PaaS token will be required and a GitHub secret, DYNATRACE_PAAS_TOKEN  creating. Information on creation of the token is here https://github.com/govuk-one-login/observability-infrastructure/tree/main/fargate#building-the-container.
- gitignore for vscode
- Cloudformation Templates
    - Giving the deployment IAM role permission to pull the secrets from di-observability-prod secrets manager
    - Pulling the values needed from the secrets
- Dockerfile change to pull the One Agent from Dynatrace container registry

Notes
- bash script needs to receive the PaaS token in someway and then authenticate against the registry. The line is there but commented out.
- Doc and what we are trying to do https://github.com/govuk-one-login/observability-infrastructure/tree/main/fargate#building-the-container
- Jira story https://govukverify.atlassian.net/browse/OBS-31 