### PR TITLE
SSE-3110: Explicit specification of log groups with Data Protection Policy

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -34,7 +34,7 @@ jobs:
       template: infrastructure/frontend/frontend.template.yml
       parameters: |
         ImageURI=${{ needs.push-frontend-image.outputs.image-uri }}
-        LogGroupPrefix=/self-service/preview
+        LogGroupPrefix=/self-service/admin-tool/preview
 
   build-cognito:
     name: Cognito
@@ -48,6 +48,7 @@ jobs:
     with:
       name: ${{ needs.build-cognito.outputs.component }}
       artifact: ${{ needs.build-cognito.outputs.artifact-name }}
+      parameters: LogGroupPrefix=/self-service/admin-tool/preview
 
   build-api:
     name: API
@@ -61,7 +62,7 @@ jobs:
     with:
       name: ${{ needs.build-api.outputs.component }}
       artifact: ${{ needs.build-api.outputs.artifact-name }}
-      parameters: LogGroupPrefix=/self-service/preview
+      parameters: LogGroupPrefix=/self-service/admin-tool/preview
 
   deploy-dynamodb:
     name: DynamoDB

--- a/backend/api/api.template.yml
+++ b/backend/api/api.template.yml
@@ -14,7 +14,7 @@ Parameters:
   LogGroupPrefix:
     Type: String
     AllowedPattern: ^.*[^\/]$
-    Default: /aws/vendedlogs
+    Default: /self-service/admin-tool
   DeploymentName:
     Type: String
     MaxLength: 28
@@ -45,6 +45,8 @@ Globals:
     VpcConfig:
       SecurityGroupIds: [ !ImportValue VPC-VPCEndpointsSecurityGroup ]
       SubnetIds: !Split [ ",", !ImportValue VPC-PrivateSubnets ]
+    LoggingConfig:
+      LogGroup: !Ref LambdaLogsGroup
     Environment:
       Variables:
         NODE_OPTIONS: --enable-source-maps
@@ -106,12 +108,11 @@ Resources:
   APIAccessLogsGroup:
     # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
     Type: AWS::Logs::LogGroup
-    DependsOn: LogAuditLogGroup
     Properties:
       LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/api
       RetentionInDays: 14
       DataProtectionPolicy:
-        Name: data-protection-policy
+        Name: data-protection-policy-api
         Description: Data Protection for Cloudwatch Logs
         Version: '2021-06-01'
         Statement:
@@ -129,7 +130,7 @@ Resources:
               Audit:
                 FindingsDestination:
                   CloudWatchLogs:
-                    LogGroup: !Sub ${LogGroupPrefix}/${DeploymentName}/api/audit
+                    LogGroup: !Ref LogAuditLogGroup
           - Sid: redact-policy
             DataIdentifier:
               - arn:aws:dataprotection::aws:data-identifier/EmailAddress
@@ -143,6 +144,47 @@ Resources:
             Operation:
               Deidentify:
                 MaskConfig: { }
+
+  LambdaLogsGroup:
+    # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/api/lambda
+      RetentionInDays: 14
+      DataProtectionPolicy:
+        Name: data-protection-policy-api-lambda
+        Description: Data Protection for Cloudwatch Logs
+        Version: '2021-06-01'
+        Statement:
+          - Sid: audit-policy
+            DataIdentifier:
+              - arn:aws:dataprotection::aws:data-identifier/EmailAddress
+              - arn:aws:dataprotection::aws:data-identifier/IpAddress
+              - arn:aws:dataprotection::aws:data-identifier/Address
+              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
+              - arn:aws:dataprotection::aws:data-identifier/OpenSshPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PuttyPrivateKey
+            Operation:
+              Audit:
+                FindingsDestination:
+                  CloudWatchLogs:
+                    LogGroup: !Ref LogAuditLogGroup
+          - Sid: redact-policy
+            DataIdentifier:
+              - arn:aws:dataprotection::aws:data-identifier/EmailAddress
+              - arn:aws:dataprotection::aws:data-identifier/IpAddress
+              - arn:aws:dataprotection::aws:data-identifier/Address
+              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
+              - arn:aws:dataprotection::aws:data-identifier/OpenSshPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PuttyPrivateKey
+            Operation:
+              Deidentify:
+                MaskConfig: { }
+
   #--- Users ---#
 
   EnvironmentVariablesEncryptionKey:
@@ -835,12 +877,11 @@ Resources:
   StepFunctionsLogGroup:
     # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
     Type: AWS::Logs::LogGroup
-    DependsOn: LogAuditLogGroup
     Properties:
       LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/api/step-functions
       RetentionInDays: 14
       DataProtectionPolicy:
-        Name: data-protection-policy
+        Name: data-protection-policy-api-step-functions
         Description: Data Protection for Cloudwatch Logs
         Version: '2021-06-01'
         Statement:
@@ -858,7 +899,7 @@ Resources:
               Audit:
                 FindingsDestination:
                   CloudWatchLogs:
-                    LogGroup: !Sub ${LogGroupPrefix}/${DeploymentName}/api/audit
+                    LogGroup: !Ref LogAuditLogGroup
           - Sid: redact-policy
             DataIdentifier:
               - arn:aws:dataprotection::aws:data-identifier/EmailAddress

--- a/backend/cognito/cognito.template.yml
+++ b/backend/cognito/cognito.template.yml
@@ -12,6 +12,10 @@ Parameters:
   DeletionProtection:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /self-service/config/deletion-protection-enabled
+  LogGroupPrefix:
+    Type: String
+    AllowedPattern: ^.*[^\/]$
+    Default: /self-service/admin-tool
   DeploymentName:
     Type: String
     MaxLength: 28
@@ -57,6 +61,8 @@ Globals:
     VpcConfig:
       SecurityGroupIds: [ !ImportValue VPC-VPCEndpointsSecurityGroup ]
       SubnetIds: !Split [ ",", !ImportValue VPC-PrivateSubnets ]
+    LoggingConfig:
+      LogGroup: !Ref LambdaLogsGroup
     Environment:
       Variables:
         NODE_OPTIONS: --enable-source-maps
@@ -114,6 +120,53 @@ Resources:
                 aws:SourceAccount: !Ref AWS::AccountId
               ArnLike:
                 aws:SourceArn: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function/*
+
+  LogAuditLogGroup:
+    # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/cognito/audit
+      RetentionInDays: 14
+
+  LambdaLogsGroup:
+    # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/cognito/lambda
+      RetentionInDays: 14
+      DataProtectionPolicy:
+        Name: data-protection-policy-cognito-lambda
+        Description: Data Protection for Cloudwatch Logs
+        Version: '2021-06-01'
+        Statement:
+          - Sid: audit-policy
+            DataIdentifier:
+              - arn:aws:dataprotection::aws:data-identifier/EmailAddress
+              - arn:aws:dataprotection::aws:data-identifier/IpAddress
+              - arn:aws:dataprotection::aws:data-identifier/Address
+              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
+              - arn:aws:dataprotection::aws:data-identifier/OpenSshPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PuttyPrivateKey
+            Operation:
+              Audit:
+                FindingsDestination:
+                  CloudWatchLogs:
+                    LogGroup: !Ref LogAuditLogGroup
+          - Sid: redact-policy
+            DataIdentifier:
+              - arn:aws:dataprotection::aws:data-identifier/EmailAddress
+              - arn:aws:dataprotection::aws:data-identifier/IpAddress
+              - arn:aws:dataprotection::aws:data-identifier/Address
+              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
+              - arn:aws:dataprotection::aws:data-identifier/OpenSshPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PuttyPrivateKey
+            Operation:
+              Deidentify:
+                MaskConfig: { }
 
   SendPasswordChangedEmailFunction:
     # checkov:skip=CKV_AWS_115:Ensure that AWS Lambda function is configured for function-level concurrent execution limit

--- a/infrastructure/ci/development/deployment-config.template.yml
+++ b/infrastructure/ci/development/deployment-config.template.yml
@@ -174,7 +174,6 @@ Resources:
                   - logs:DeleteSubscriptionFilter
                   - logs:DescribeSubscriptionFilters
                   - logs:PutSubscriptionFilter
-
               - Effect: Allow
                 Resource: !Sub arn:aws:logs:${AWS::Region}:${SplunkLiveAccountId}:destination:*
                 Action:
@@ -193,6 +192,26 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
+          - Effect: Allow
+            Resource: "*"
+            Action:
+              - logs:DescribeLogGroups
+              - logs:TagResource
+              - logs:CreateLogGroup
+              - logs:DeleteLogGroup
+              - logs:PutRetentionPolicy
+              - logs:CreateLogDelivery
+              - logs:PutResourcePolicy
+              - logs:DescribeResourcePolicies
+
+          - Effect: Allow
+            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:*
+            Action:
+              - logs:PutDataProtectionPolicy
+              - logs:DeleteDataProtectionPolicy
+              - logs:GetDataProtectionPolicy
+              - logs:Unmask
+
           - Effect: Allow
             Resource: "*"
             Action:
@@ -384,7 +403,7 @@ Resources:
               - logs:DescribeResourcePolicies
 
           - Effect: Allow
-            Resource: arn:aws:logs:::log-group:*:*
+            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:*
             Action:
               - logs:PutDataProtectionPolicy
               - logs:DeleteDataProtectionPolicy
@@ -469,7 +488,10 @@ Resources:
                 lambda:Principal: apigateway.amazonaws.com
 
           - Effect: Allow
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/${ServiceName}/${PreviewStacksPrefix}/${PreviewStacksPrefix}-*/api*:log-stream:*
+            Resource:
+              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/${ServiceName}/${PreviewStacksPrefix}/${PreviewStacksPrefix}-*/api*:log-stream:*
+              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/${ServiceName}/admin-tool/${PreviewStacksPrefix}/${PreviewStacksPrefix}-*/api*:log-stream:*
+              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/${ServiceName}/product-pages/${PreviewStacksPrefix}/${PreviewStacksPrefix}-*/api*:log-stream:*
             Action:
               - logs:TagResource
               - logs:CreateLogGroup
@@ -663,7 +685,11 @@ Resources:
             Effect: Allow
             Resource:
               - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/${ServiceName}/${PreviewStacksPrefix}/*
+              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/${ServiceName}/admin-tool/${PreviewStacksPrefix}/*
+              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/${ServiceName}/product-pages/${PreviewStacksPrefix}/*
               - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/${ServiceName}/dev/*
+              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/${ServiceName}/admin-tool/dev/*
+              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/${ServiceName}/product-pages/dev/*
               - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:aws-waf-logs-*-dev:log-stream:*
             Action:
               - logs:CreateLogStream

--- a/infrastructure/dev/deploy.sh
+++ b/infrastructure/dev/deploy.sh
@@ -30,7 +30,7 @@ COMMANDS=("${DEPLOY_CMDS[@]}" run open list exports delete help)
 ../aws.sh check-current-account development &> /dev/null || eval "$(gds aws di-onboarding-development -e)"
 USER_NAME=$(../aws.sh get-user-name)
 ECR_REPO=self-service/frontend
-LOG_PREFIX=/self-service/dev
+LOG_PREFIX=/self-service/admin-tool/dev
 REPO_ROOT=$(pwd)/../..
 OPTION_REGEX="^--?.*"
 DEV_PREFIX=dev

--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -13,7 +13,7 @@ Parameters:
   LogGroupPrefix:
     Type: String
     AllowedPattern: ^.*[^\/]$
-    Default: /aws/vendedlogs
+    Default: /self-service/admin-tool
   DeploymentName:
     Type: String
     MaxLength: 28
@@ -139,10 +139,56 @@ Resources:
             Options:
               # Consider lines not starting with whitespace as a multi-line log message boundary
               awslogs-multiline-pattern: ^[^\s}]+.*$
-              awslogs-group: !Sub ${LogGroupPrefix}/${DeploymentName}/frontend
+              awslogs-group: !Ref FrontendLogsGroup
               awslogs-stream-prefix: ecs
-              awslogs-create-group: true
               awslogs-region: !Ref AWS::Region
+
+  LogAuditLogGroup:
+    # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/frontend/audit
+      RetentionInDays: 14
+
+  FrontendLogsGroup:
+    # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/frontend
+      RetentionInDays: 14
+      DataProtectionPolicy:
+        Name: data-protection-policy-frontend
+        Description: Data Protection for Cloudwatch Logs
+        Version: '2021-06-01'
+        Statement:
+          - Sid: audit-policy
+            DataIdentifier:
+              - arn:aws:dataprotection::aws:data-identifier/EmailAddress
+              - arn:aws:dataprotection::aws:data-identifier/IpAddress
+              - arn:aws:dataprotection::aws:data-identifier/Address
+              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
+              - arn:aws:dataprotection::aws:data-identifier/OpenSshPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PuttyPrivateKey
+            Operation:
+              Audit:
+                FindingsDestination:
+                  CloudWatchLogs:
+                    LogGroup: !Ref LogAuditLogGroup
+          - Sid: redact-policy
+            DataIdentifier:
+              - arn:aws:dataprotection::aws:data-identifier/EmailAddress
+              - arn:aws:dataprotection::aws:data-identifier/IpAddress
+              - arn:aws:dataprotection::aws:data-identifier/Address
+              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
+              - arn:aws:dataprotection::aws:data-identifier/OpenSshPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PuttyPrivateKey
+            Operation:
+              Deidentify:
+                MaskConfig: { }
 
   ExecutionRole:
     Type: AWS::IAM::Role
@@ -158,13 +204,6 @@ Resources:
             Principal:
               Service: ecs-tasks.amazonaws.com
       Policies:
-        - PolicyName: CreateLogGroup
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action: logs:CreateLogGroup
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${LogGroupPrefix}/${DeploymentName}/frontend*
         - PolicyName: GetDynatraceSecret
           PolicyDocument:
             Version: 2012-10-17


### PR DESCRIPTION
This PR aims to explicitly declare the LogGroups used by the core services in the stack and apply Data Protection Policies to each to redact PII, goes hand in hand with https://github.com/govuk-one-login/onboarding-product-page/pull/276.

This includes separation of log groups **so that admin-tool and product pages don't share the same log groups** (and can therefore manage their own policies). This essentially means adding an additional application separator to the LogGroupPrefix, which changes from `/self-service` to `/self-service/[ product-pages | admin-tool ]`.