### PR TITLE
SSE-3150: Removed LogGroupPrefix as input parameter

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -34,7 +34,6 @@ jobs:
       template: infrastructure/frontend/frontend.template.yml
       parameters: |
         ImageURI=${{ needs.push-frontend-image.outputs.image-uri }}
-        LogGroupPrefix=/self-service/admin-tool/preview
 
   build-cognito:
     name: Cognito
@@ -48,7 +47,6 @@ jobs:
     with:
       name: ${{ needs.build-cognito.outputs.component }}
       artifact: ${{ needs.build-cognito.outputs.artifact-name }}
-      parameters: LogGroupPrefix=/self-service/admin-tool/preview
 
   build-api:
     name: API
@@ -62,7 +60,6 @@ jobs:
     with:
       name: ${{ needs.build-api.outputs.component }}
       artifact: ${{ needs.build-api.outputs.artifact-name }}
-      parameters: LogGroupPrefix=/self-service/admin-tool/preview
 
   deploy-dynamodb:
     name: DynamoDB

--- a/backend/api/api.template.yml
+++ b/backend/api/api.template.yml
@@ -3,34 +3,6 @@ Description: DI Self-Service API
 Transform: [ AWS::LanguageExtensions, AWS::Serverless-2016-10-31 ]
 
 Parameters:
-  ClientRegistryEndpoint:
-    Type: String
-    Default: https://oidc.integration.account.gov.uk
-    Description: Auth client registration endpoint
-  NotificationEmail:
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: /self-service/api/notifications-email
-    Description: Email address to send internal notifications
-  LogGroupPrefix:
-    Type: String
-    AllowedPattern: ^.*[^\/]$
-    Default: /self-service/admin-tool
-  DeploymentName:
-    Type: String
-    MaxLength: 28
-    AllowedPattern: ^.*[^-]$
-    Default: self-service
-    Description: A unique prefix to identify the deployment; used when importing or exporting values from related stacks
-  PrivateAPI:
-    Type: String
-    AllowedValues: [ Yes, No ]
-    Default: Yes
-  PermissionsBoundary:
-    Type: String
-    Default: ""
-  CodeSigningConfigArn:
-    Type: String
-    Default: ""
   Environment:
     Description: "The name of the environment to deploy to."
     Type: "String"
@@ -42,25 +14,71 @@ Parameters:
       - "staging"
       - "integration"
       - "production"
+  DeploymentName:
+    Type: String
+    MaxLength: 22
+    AllowedPattern: ^.*[^-]$
+    Default: self-service
+    Description: A unique prefix to identify the deployment; used to distinguish variation between ephemeral stacks
+  ClientRegistryEndpoint:
+    Type: String
+    Default: https://oidc.integration.account.gov.uk
+    Description: Auth client registration endpoint
+  NotificationEmail:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /self-service/api/notifications-email
+    Description: Email address to send internal notifications
+  PrivateAPI:
+    Type: String
+    AllowedValues: [ Yes, No ]
+    Default: Yes
+  PermissionsBoundary:
+    Type: String
+    Default: ""
+  CodeSigningConfigArn:
+    Type: String
+    Default: ""
+
+Rules:
+  DeploymentNameRequired:
+    RuleCondition: !Equals [ !Ref Environment, "local" ]
+    Assertions:
+      - Assert: !Not [ !Equals [ !Ref DeploymentName, "" ] ]
+        AssertDescription: >
+          Must specify DeploymentName parameter when Environment is "local"
+
+  DeploymentNameMustBeEmpty:
+    RuleCondition: !Not [ !Equals [ !Ref Environment, "local" ] ]
+    Assertions:
+      - Assert: !Equals [ !Ref DeploymentName, "self-service" ] # Confirm the default value is used.
+        AssertDescription: >
+          Must not specify DeploymentName parameter when Environment is not "local"
 
 Mappings:
   EnvironmentConfiguration:
-    local: # Local builds do not support dynatrace
+    local:
+      logGroupPrefix: /self-service/admin-tool/backend-api
+      # Local builds do not support dynatrace
       dynatraceLoggingEnabled: false
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     dev:
+      logGroupPrefix: /self-service/admin-tool/backend-api
       dynatraceLoggingEnabled: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     build:
+      logGroupPrefix: /self-service/admin-tool/backend-api
       dynatraceLoggingEnabled: false
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     staging:
+      logGroupPrefix: /self-service/admin-tool/backend-api
       dynatraceLoggingEnabled: false
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     integration:
+      logGroupPrefix: /self-service/admin-tool/backend-api
       dynatraceLoggingEnabled: false
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     production:
+      logGroupPrefix: /self-service/admin-tool/backend-api
       dynatraceLoggingEnabled: false
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
 
@@ -69,6 +87,7 @@ Conditions:
   UseCodeSigning: !Not [ !Equals [ !Ref CodeSigningConfigArn, "" ] ]
   UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundary, "" ] ]
   DynatraceLoggingEnabled: !Equals [ !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceLoggingEnabled ], true ]
+  IsLocal: !Equals [ !Ref Environment, "local" ]
 
 Globals:
   Function:
@@ -174,14 +193,22 @@ Resources:
     # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/api/audit
+      LogGroupName: !Join
+        - "/"
+        - - !FindInMap [ EnvironmentConfiguration, !Ref Environment, logGroupPrefix ]
+          - !If [ IsLocal, !Ref DeploymentName, !Ref AWS::NoValue ]
+          - 'audit'
       RetentionInDays: 14
 
   APIAccessLogsGroup:
     # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/api
+      LogGroupName: !Join
+        - "/"
+        - - !FindInMap [ EnvironmentConfiguration, !Ref Environment, logGroupPrefix ]
+          - !If [ IsLocal, !Ref DeploymentName, !Ref AWS::NoValue ]
+          - 'api'
       RetentionInDays: 14
       DataProtectionPolicy:
         Name: data-protection-policy-api
@@ -221,7 +248,11 @@ Resources:
     # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/api/lambda
+      LogGroupName: !Join
+        - "/"
+        - - !FindInMap [ EnvironmentConfiguration, !Ref Environment, logGroupPrefix ]
+          - !If [ IsLocal, !Ref DeploymentName, !Ref AWS::NoValue ]
+          - 'lambda'
       RetentionInDays: 14
       DataProtectionPolicy:
         Name: data-protection-policy-api-lambda
@@ -1000,7 +1031,11 @@ Resources:
     # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/api/step-functions
+      LogGroupName: !Join
+        - "/"
+        - - !FindInMap [ EnvironmentConfiguration, !Ref Environment, logGroupPrefix ]
+          - !If [ IsLocal, !Ref DeploymentName, !Ref AWS::NoValue ]
+          - 'step-functions'
       RetentionInDays: 14
       DataProtectionPolicy:
         Name: data-protection-policy-api-step-functions

--- a/backend/cognito/cognito.template.yml
+++ b/backend/cognito/cognito.template.yml
@@ -3,6 +3,23 @@ Description: Cognito UserPool and Client for the Admin Tool
 Transform: AWS::Serverless-2016-10-31
 
 Parameters:
+  Environment:
+    Description: "The name of the environment to deploy to."
+    Type: "String"
+    Default: local
+    AllowedValues:
+      - "local"
+      - "dev"
+      - "build"
+      - "staging"
+      - "integration"
+      - "production"
+  DeploymentName:
+    Type: String
+    MaxLength: 22
+    AllowedPattern: ^.*[^-]$
+    Default: self-service
+    Description: A unique prefix to identify the deployment; used to distinguish variation between ephemeral stacks
   ExternalId:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /self-service/cognito/external-id
@@ -12,16 +29,6 @@ Parameters:
   DeletionProtection:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /self-service/config/deletion-protection-enabled
-  LogGroupPrefix:
-    Type: String
-    AllowedPattern: ^.*[^\/]$
-    Default: /self-service/admin-tool
-  DeploymentName:
-    Type: String
-    MaxLength: 28
-    AllowedPattern: ^.*[^-]$
-    Default: self-service
-    Description: A unique prefix to identify the deployment; used when importing or exporting values from related stacks
   EmailSenderID:
     Type: String
     Default: GOV.UK One Login
@@ -34,39 +41,50 @@ Parameters:
   CodeSigningConfigArn:
     Type: String
     Default: ""
-  Environment:
-    Description: "The name of the environment to deploy to."
-    Type: "String"
-    Default: local
-    AllowedValues:
-      - "local"
-      - "dev"
-      - "build"
-      - "staging"
-      - "integration"
-      - "production"
   SubscriptionFilterDestinationArn:
     Type: String
     Default: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
 
+Rules:
+  DeploymentNameRequired:
+    RuleCondition: !Equals [ !Ref Environment, "local" ]
+    Assertions:
+      - Assert: !Not [ !Equals [ !Ref DeploymentName, "" ] ]
+        AssertDescription: >
+          Must specify DeploymentName parameter when Environment is "local"
+
+  DeploymentNameMustBeEmpty:
+    RuleCondition: !Not [ !Equals [ !Ref Environment, "local" ] ]
+    Assertions:
+      - Assert: !Equals [ !Ref DeploymentName, "self-service" ] # Confirm the default value is used.
+        AssertDescription: >
+          Must not specify DeploymentName parameter when Environment is not "local"
+
 Mappings:
   EnvironmentConfiguration:
-    local: # Local builds do not support dynatrace
+    local:
+      logGroupPrefix: /self-service/admin-tool/cognito
+      # Local builds do not support dynatrace
       dynatraceLoggingEnabled: false
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     dev:
+      logGroupPrefix: /self-service/admin-tool/cognito
       dynatraceLoggingEnabled: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     build:
+      logGroupPrefix: /self-service/admin-tool/cognito
       dynatraceLoggingEnabled: false
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     staging:
+      logGroupPrefix: /self-service/admin-tool/cognito
       dynatraceLoggingEnabled: false
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     integration:
+      logGroupPrefix: /self-service/admin-tool/cognito
       dynatraceLoggingEnabled: false
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     production:
+      logGroupPrefix: /self-service/admin-tool/cognito
       dynatraceLoggingEnabled: false
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
 
@@ -75,6 +93,7 @@ Conditions:
   UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundary, "" ] ]
   SplunkLoggingEnabled: !Or [!Equals [ !Ref Environment, integration ], !Equals [ !Ref Environment, production ]]
   DynatraceLoggingEnabled: !Equals [ !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceLoggingEnabled ], true ]
+  IsLocal: !Equals [ !Ref Environment, "local" ]
 
 Globals:
   Function:
@@ -188,14 +207,22 @@ Resources:
     # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/cognito/audit
+      LogGroupName: !Join
+        - "/"
+        - - !FindInMap [ EnvironmentConfiguration, !Ref Environment, logGroupPrefix ]
+          - !If [ IsLocal, !Ref DeploymentName, !Ref AWS::NoValue ]
+          - 'audit'
       RetentionInDays: 14
 
   LambdaLogsGroup:
     # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/cognito/lambda
+      LogGroupName: !Join
+        - "/"
+        - - !FindInMap [ EnvironmentConfiguration, !Ref Environment, logGroupPrefix ]
+          - !If [ IsLocal, !Ref DeploymentName, !Ref AWS::NoValue ]
+          - 'lambda'
       RetentionInDays: 14
       DataProtectionPolicy:
         Name: data-protection-policy-cognito-lambda
@@ -960,7 +987,11 @@ Resources:
     # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub aws-waf-logs-${AWS::StackName}-${Environment}
+      LogGroupName: !Join
+        - ""
+        - - 'aws-waf-logs'
+          - !Join [ '-', !Split [ '/', !FindInMap [ EnvironmentConfiguration, !Ref Environment, logGroupPrefix ] ] ]
+          - !If [ IsLocal, !Sub '-${DeploymentName}', !Ref AWS::NoValue ]
       RetentionInDays: 30
 
   WafLoggingConfiguration:

--- a/infrastructure/dev/deploy.sh
+++ b/infrastructure/dev/deploy.sh
@@ -30,7 +30,6 @@ COMMANDS=("${DEPLOY_CMDS[@]}" run open list exports delete help)
 ../aws.sh check-current-account development &> /dev/null || eval "$(gds aws di-onboarding-development -e)"
 USER_NAME=$(../aws.sh get-user-name)
 ECR_REPO=self-service/frontend
-LOG_PREFIX=/self-service/admin-tool/dev
 REPO_ROOT=$(pwd)/../..
 OPTION_REGEX="^--?.*"
 DEV_PREFIX=dev
@@ -113,7 +112,7 @@ function deploy {
     ${template:+--template $template} \
     ${STACK_PREFIX:+--stack-name $STACK_PREFIX-$component} \
     --tags sse:component="$component" sse:stack-type=dev sse:stack-role=application sse:owner="$USER_NAME" \
-    --params ${STACK_PREFIX:+DeploymentName=$STACK_PREFIX} LogGroupPrefix=$LOG_PREFIX
+    --params ${STACK_PREFIX:+DeploymentName=$STACK_PREFIX}
 
   popd > /dev/null
 }

--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -3,6 +3,23 @@ Description: DI Admin Tool frontend
 Transform: AWS::LanguageExtensions
 
 Parameters:
+  Environment:
+    Description: "The name of the environment to deploy to."
+    Type: "String"
+    Default: local
+    AllowedValues:
+      - "local"
+      - "dev"
+      - "build"
+      - "staging"
+      - "integration"
+      - "production"
+  DeploymentName:
+    Type: String
+    MaxLength: 22
+    AllowedPattern: ^.*[^-]$
+    Default: self-service
+    Description: A unique prefix to identify the deployment; used to distinguish variation between ephemeral stacks
   ImageURI:
     Type: String
     Default: ""
@@ -10,16 +27,6 @@ Parameters:
   ContainerPort:
     Type: Number
     Default: 3000
-  LogGroupPrefix:
-    Type: String
-    AllowedPattern: ^.*[^\/]$
-    Default: /self-service/admin-tool
-  DeploymentName:
-    Type: String
-    MaxLength: 28
-    AllowedPattern: ^.*[^-]$
-    Default: self-service
-    Description: A unique prefix to identify the deployment; used when importing or exporting values from related stacks
   ShowTestBanner:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /self-service/frontend/show-test-banner
@@ -45,24 +52,44 @@ Parameters:
     Type: String
     Default: ""
     Description: The ARN of the permissions boundary to apply when creating IAM roles
-  Environment:
-    Description: "The name of the environment to deploy to."
-    Type: "String"
-    Default: dev
-    AllowedValues:
-      - "dev"
-      - "build"
-      - "staging"
-      - "integration"
-      - "production"
+
+Rules:
+  DeploymentNameRequired:
+    RuleCondition: !Equals [ !Ref Environment, "local" ]
+    Assertions:
+      - Assert: !Not [ !Equals [ !Ref DeploymentName, "" ] ]
+        AssertDescription: >
+          Must specify DeploymentName parameter when Environment is "local"
+
+  DeploymentNameMustBeEmpty:
+    RuleCondition: !Not [ !Equals [ !Ref Environment, "local" ] ]
+    Assertions:
+      - Assert: !Equals [ !Ref DeploymentName, "self-service" ] # Confirm the default value is used.
+        AssertDescription: >
+          Must not specify DeploymentName parameter when Environment is not "local"
 
 Mappings:
+  EnvironmentConfiguration:
+    local:
+      logGroupPrefix: /self-service/admin-tool/frontend
+    dev:
+      logGroupPrefix: /self-service/admin-tool/frontend
+    build:
+      logGroupPrefix: /self-service/admin-tool/frontend
+    staging:
+      logGroupPrefix: /self-service/admin-tool/frontend
+    integration:
+      logGroupPrefix: /self-service/admin-tool/frontend
+    production:
+      logGroupPrefix: /self-service/admin-tool/frontend
+
   # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancer:
     eu-west-2:
       AccountID: 652711504416
   TxMAAccountARN:
     Environment:
+      local: 'arn:aws:iam::494650018671:root'
       dev: 'arn:aws:iam::494650018671:root'
       build: 'arn:aws:iam::399055180839:root'
       staging: 'arn:aws:iam::178023842775:root'
@@ -72,6 +99,7 @@ Mappings:
 Conditions:
   Subdomain: !Not [ !Equals [ !Ref DeploymentName, self-service ] ]
   UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundary, "" ] ]
+  IsLocal: !Equals [ !Ref Environment, "local" ]
 
 Resources:
 
@@ -147,14 +175,22 @@ Resources:
     # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/frontend/audit
+      LogGroupName: !Join
+        - "/"
+        - - !FindInMap [ EnvironmentConfiguration, !Ref Environment, logGroupPrefix ]
+          - !If [ IsLocal, !Ref DeploymentName, !Ref AWS::NoValue ]
+          - 'audit'
       RetentionInDays: 14
 
   FrontendLogsGroup:
     # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/frontend
+      LogGroupName: !Join
+        - "/"
+        - - !FindInMap [ EnvironmentConfiguration, !Ref Environment, logGroupPrefix ]
+          - !If [ IsLocal, !Ref DeploymentName, !Ref AWS::NoValue ]
+          - 'ecr'
       RetentionInDays: 14
       DataProtectionPolicy:
         Name: data-protection-policy-frontend


### PR DESCRIPTION
Taking into consideration that [Secure Pipelines does not publish custom input parameters](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3193831452/Stack+parameters+provided+by+the+pipeline), it is best to vary the [CloudFormation stack configuration](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3071705136/How+to+create+a+configuration+pipeline#Step-2%3A-Use-CloudFormation-mappings-to-vary-the-parameter-values-by-environment) based on `Environment` instead.

Because the value of `LogGroupPrefix` is already set (to the default value) for established environments it is necessary to remove this completely (because the default value can not now be changed).

Setting some rules for `DeploymentName`, so that this only varies from the default value for ephemeral environments.