### PR TITLE
SSE-3278: Template value not needed after a sam build.

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run: { working-directory: express }
+    outputs:
+      artifact-name: ${{ inputs.artifact-name }}
 
     steps:
       - name: Pull repository

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -29,7 +29,8 @@ jobs:
     needs: [ push-frontend-image, deploy-api, deploy-cognito, deploy-dynamodb ]
     uses: ./.github/workflows/deploy-component.yml
     with:
-      name: Frontend
+      name: frontend
+      artifact: ${{ needs.build-frontend.outputs.artifact-name }}
       deployment-url-output: AdminToolURL
       template: infrastructure/frontend/frontend.template.yml
       parameters: |
@@ -47,7 +48,6 @@ jobs:
     with:
       name: ${{ needs.build-cognito.outputs.component }}
       artifact: ${{ needs.build-cognito.outputs.artifact-name }}
-      template: backend/cognito/cognito.template.yml
 
   build-api:
     name: API
@@ -61,11 +61,10 @@ jobs:
     with:
       name: ${{ needs.build-api.outputs.component }}
       artifact: ${{ needs.build-api.outputs.artifact-name }}
-      template: backend/api/api.template.yml
 
   deploy-dynamodb:
     name: DynamoDB
     uses: ./.github/workflows/deploy-component.yml
     with:
-      name: DynamoDB
+      name: dynamodb
       template: backend/dynamodb/dynamodb.template.yml

--- a/.github/workflows/deploy-component.yml
+++ b/.github/workflows/deploy-component.yml
@@ -51,10 +51,12 @@ jobs:
           stack-name-prefix: preview-${{ inputs.name }}
           artifact-name: ${{ inputs.artifact }}
           template: ${{ inputs.template }}
+          cache-name: ${{ inputs.name }}
           s3-prefix: sse-preview
           tags: |-
             sse:component=${{ inputs.name }}
             sse:stack-type=preview
+            sse:stack-name=preview-${{ inputs.name }}
             sse:application=self-service
             sse:deployment-source=github-actions
           parameters: |-


### PR DESCRIPTION
In short, there were two issues:

- Templates that contain lambdas and need to run `sam build` (api & cognito) should not pass a template file to `sam deploy` but use the assets in `.aws-sam` from the build step.
- This requires that caching and artifact use between jobs be correctly separated (cache key names changed in the latest github-actions code), otherwise one component may use the built assets from another.