### PR TITLE
SSE-3319: Updated oneagent image source.

### DIFF
--- a/infrastructure/frontend/Dockerfile
+++ b/infrastructure/frontend/Dockerfile
@@ -16,7 +16,7 @@ COPY express/stubs stubs
 COPY express/resources resources
 COPY express/src/views src/views
 COPY express/assets/images assets/images
-COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs / /
 ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
 USER node


### PR DESCRIPTION
The Self-Service Experience also uses an Alpine base image (Product Pages uses a default debian image), and according to the [documentation alpine images require a different version of the OneAgent](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3755901029/Dynatrace+One+Agent+for+Lambda+and+ECS#Building-the-container) - “Using an Alpine base image, use oneagent-codemodules-musl instead for the image name.”