### PR TITLE
Update api.template.yml

### DIFF
--- a/backend/api/api.template.yml
+++ b/backend/api/api.template.yml
@@ -82,6 +82,9 @@ Mappings:
       cslsLoggingEnabled: true
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       clslSubscriptionFilterArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
+    default:
+      cslsLoggingEnabled: false
+      dynatraceLoggingEnabled: false
   WafArn:
     Environment:
       local: "/self-service/development/waf-web-acl"


### PR DESCRIPTION
This is necessary because of a new linting warning in cfn-lint (not present in the cfn-lint version used by `sam validate --lint`).