### PR TITLE
BAU: Update express-session to remediate vulnerability

### DIFF
--- a/express/package.json
+++ b/express/package.json
@@ -24,7 +24,7 @@
     "connect-dynamodb": "^3.0.5",
     "express": "^4.21.2",
     "express-async-errors": "^3.1.1",
-    "express-session": "^1.17.3",
+    "express-session": "^1.18.2",
     "googleapis": "^148.0.0",
     "googleapis-common": "^7.2.0",
     "govuk-frontend": "^5.11.0",
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.17",
-    "@types/express-session": "^1.18.1",
+    "@types/express-session": "^1.18.2",
     "@types/node": "^20.17.47",
     "@types/nunjucks": "^3.2.2",
     "@types/uuid": "^9.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,7 @@
         "connect-dynamodb": "^3.0.5",
         "express": "^4.21.2",
         "express-async-errors": "^3.1.1",
-        "express-session": "^1.17.3",
+        "express-session": "^1.18.2",
         "googleapis": "^148.0.0",
         "googleapis-common": "^7.2.0",
         "govuk-frontend": "^5.11.0",
@@ -118,7 +118,7 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.17",
-        "@types/express-session": "^1.18.1",
+        "@types/express-session": "^1.18.2",
         "@types/node": "^20.17.47",
         "@types/nunjucks": "^3.2.2",
         "@types/uuid": "^9.0.1",
@@ -5908,9 +5908,9 @@
       }
     },
     "node_modules/@types/express-session": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.18.1.tgz",
-      "integrity": "sha512-S6TkD/lljxDlQ2u/4A70luD8/ZxZcrU5pQwI1rVXCiaVIywoFgbA+PIUNDjPhQpPdK0dGleLtYc/y7XWBfclBg==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-k+I0BxwVXsnEU2hV77cCobC08kIsn4y44C3gC0b46uxZVMaXA04lSPgRLR/bSL2w0t0ShJiG8o4jPzRG/nscFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8134,15 +8134,16 @@
       }
     },
     "node_modules/express-session": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
-      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+      "license": "MIT",
       "dependencies": {
         "cookie": "0.7.2",
         "cookie-signature": "1.0.7",
         "debug": "2.6.9",
         "depd": "~2.0.0",
-        "on-headers": "~1.0.2",
+        "on-headers": "~1.1.0",
         "parseurl": "~1.3.3",
         "safe-buffer": "5.2.1",
         "uid-safe": "~2.1.5"
@@ -10655,9 +10656,10 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }


### PR DESCRIPTION
- dependabot alerted us to a [vulnerability](https://github.com/govuk-one-login/onboarding-self-service-experience/security/dependabot/100) in `on-headers` which is a dependency of express-session
- minor version update to express-session to latest version (1.18.2) which uses a patched version of on-headers

Deployed to dev to test by logging in, creating a service and changing config values for a service.